### PR TITLE
fix(bay): install curl in runtime image for healthcheck

### DIFF
--- a/pkgs/bay/Dockerfile
+++ b/pkgs/bay/Dockerfile
@@ -22,6 +22,11 @@ FROM python:3.13-slim
 
 WORKDIR /app
 
+# Install curl for container health checks
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy virtual environment from builder
 COPY --from=builder /app/.venv /app/.venv
 


### PR DESCRIPTION
修复 Bay 镜像健康检查问题（Issue #3）

## 变更
- 在 `pkgs/bay/Dockerfile` 的运行时阶段安装 `curl`，因为基础镜像 `python:3.13-slim` 默认不包含 `curl`。
- 这样现有 `HEALTHCHECK`（`curl -f http://localhost:8114/health`）可以正常执行。
