### PR TITLE
feat: add multi-arch (amd64+arm64) Docker image builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,7 @@
 #   - 手动触发 (workflow_dispatch) → 构建并推送 :latest + :sha-xxxxx
 #
 # 构建三个镜像: bay, ship, gull
+# 每个镜像使用原生 runner 分别构建 amd64 和 arm64，然后合并为多架构 manifest。
 
 name: CD
 
@@ -26,15 +27,22 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # ── 构建 Bay 镜像 ─────────────────────────────────────────
-  build-bay:
-    name: "Build Bay"
-    runs-on: ubuntu-latest
+  # ── 构建各平台镜像 ─────────────────────────────────────────
+  build:
+    name: "Build ${{ matrix.component }} (${{ matrix.platform }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [bay, ship, gull]
+        platform: [linux/amd64, linux/arm64]
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -49,7 +57,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_PREFIX }}-bay
+          images: ${{ env.IMAGE_PREFIX }}-${{ matrix.component }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -57,26 +65,46 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
-          context: pkgs/bay
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          context: pkgs/${{ matrix.component }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          outputs: type=image,"name=${{ env.IMAGE_PREFIX }}-${{ matrix.component }}",push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.component }}-${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.component }}-${{ matrix.platform }},mode=max
 
-  # ── 构建 Ship 镜像 ────────────────────────────────────────
-  build-ship:
-    name: "Build Ship"
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.component }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ── 合并多架构 manifest ────────────────────────────────────
+  merge:
+    name: "Merge ${{ matrix.component }}"
     runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        component: [bay, ship, gull]
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digest-${{ matrix.component }}-*
+          merge-multiple: true
 
       - uses: docker/setup-buildx-action@v3
 
@@ -91,7 +119,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_PREFIX }}-ship
+          images: ${{ env.IMAGE_PREFIX }}-${{ matrix.component }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -99,55 +127,13 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: pkgs/ship
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_PREFIX }}-${{ matrix.component }}@sha256:%s ' *)
 
-  # ── 构建 Gull 镜像 ────────────────────────────────────────
-  build-gull:
-    name: "Build Gull"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE_PREFIX }}-gull
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: pkgs/gull
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect "${{ env.IMAGE_PREFIX }}-${{ matrix.component }}:${{ steps.meta.outputs.version }}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,7 @@
 #   - 手动触发 (workflow_dispatch) → 构建并推送 :latest + :sha-xxxxx
 #
 # 构建三个镜像: bay, ship, gull
+# 每个镜像使用原生 runner 分别构建 amd64 和 arm64，然后合并为多架构 manifest。
 
 name: CD
 
@@ -26,15 +27,22 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # ── 构建 Bay 镜像 ─────────────────────────────────────────
-  build-bay:
-    name: "Build Bay"
-    runs-on: ubuntu-latest
+  # ── 构建各平台镜像 ─────────────────────────────────────────
+  build:
+    name: "Build ${{ matrix.component }} (${{ matrix.platform }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [bay, ship, gull]
+        platform: [linux/amd64, linux/arm64]
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -49,7 +57,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_PREFIX }}-bay
+          images: ${{ env.IMAGE_PREFIX }}-${{ matrix.component }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -57,26 +65,46 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
-          context: pkgs/bay
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          context: pkgs/${{ matrix.component }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          outputs: type=image,"name=${{ env.IMAGE_PREFIX }}-${{ matrix.component }}",push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.component }}-${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.component }}-${{ matrix.platform }},mode=max
 
-  # ── 构建 Ship 镜像 ────────────────────────────────────────
-  build-ship:
-    name: "Build Ship"
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.component }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ── 合并多架构 manifest ────────────────────────────────────
+  merge:
+    name: "Merge ${{ matrix.component }}"
     runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        component: [bay, ship, gull]
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digest-${{ matrix.component }}-*
+          merge-multiple: true
 
       - uses: docker/setup-buildx-action@v3
 
@@ -91,7 +119,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_PREFIX }}-ship
+          images: ${{ env.IMAGE_PREFIX }}-${{ matrix.component }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -99,55 +127,14 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: pkgs/ship
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_PREFIX }}-${{ matrix.component }}@sha256:%s ' *)
 
-  # ── 构建 Gull 镜像 ────────────────────────────────────────
-  build-gull:
-    name: "Build Gull"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE_PREFIX }}-gull
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: pkgs/gull
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Inspect image
+        run: |
+          tag=$(jq -cr '.tags[0]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          docker buildx imagetools inspect "$tag"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,6 +33,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
@@ -58,6 +61,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: pkgs/bay
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -70,6 +74,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -96,6 +103,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: pkgs/ship
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -108,6 +116,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -134,6 +145,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: pkgs/gull
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Problem

CI only builds `linux/amd64` images. On Apple Silicon Macs, these run under Rosetta 2 where **Ship's `/shell/exec` endpoint hangs indefinitely** due to fork/exec syscall translation issues, making the sandbox non-functional.

## Solution

Build multi-arch images (`linux/amd64` + `linux/arm64`) using **native ARM64 GitHub-hosted runners** (`ubuntu-24.04-arm`, free for public repos) — no QEMU needed.

### Build architecture

```
build (matrix: 3 components × 2 platforms = 6 parallel native jobs)
├── bay   × amd64  (ubuntu-latest)
├── bay   × arm64  (ubuntu-24.04-arm)
├── ship  × amd64  (ubuntu-latest)
├── ship  × arm64  (ubuntu-24.04-arm)
├── gull  × amd64  (ubuntu-latest)
└── gull  × arm64  (ubuntu-24.04-arm)

merge (3 jobs, waits for build)
├── bay   → multi-arch manifest
├── ship  → multi-arch manifest
└── gull  → multi-arch manifest
```

Each platform builds and pushes by digest; the merge job combines them into a single multi-arch manifest via `docker buildx imagetools create`.

## Changes

- **[.github/workflows/cd.yml](file:///Users/xiangyang/Documents/GitHub/shipyard-neo/.github/workflows/cd.yml)**: Rewrite to matrix strategy with native runners + manifest merge

## Testing

Locally built ARM64 images on Apple Silicon Mac (M4, OrbStack):

| Test | Rosetta (amd64) | Native (arm64) |
|---|---|---|
| `GET /health` | ✅ OK | ✅ OK |
| `POST /shell/exec` | ❌ Hangs forever | ✅ 131ms |
| `uname -m` | x86_64 | aarch64 |


resolve #6
