### PR TITLE
fix(cd): also lowercase bug

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,8 +20,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  # github.repository is always lowercase (e.g. "astrbotdevs/shipyard-neo")
-  IMAGE_PREFIX: ghcr.io/${{ github.repository }}
+  IMAGE_PREFIX: ghcr.io/astrbotdevs/shipyard-neo
 
 concurrency:
   group: cd-${{ github.ref }}


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the container image prefix in the CD workflow to avoid issues caused by automatic lowercasing of github.repository.