### PR TITLE
fix:  change CONTAINER_NAME_PREFIX  for "bay-session-" to "bay-"

### DIFF
--- a/pkgs/bay/app/services/gc/tasks/orphan_container.py
+++ b/pkgs/bay/app/services/gc/tasks/orphan_container.py
@@ -1,7 +1,7 @@
 """OrphanContainerGC - Clean up orphan containers (Strict mode).
 
 SAFETY FIRST: This task only deletes containers that:
-1. Have name prefix "bay-session-"
+1. Have name prefix "bay-"
 2. Have ALL required labels (bay.session_id, bay.sandbox_id, etc.)
 3. Have bay.managed="true"
 4. Have bay.instance_id matching the configured gc.instance_id
@@ -38,7 +38,7 @@ REQUIRED_LABELS = [
 ]
 
 # Container name prefix for Bay-managed containers
-CONTAINER_NAME_PREFIX = "bay-session-"
+CONTAINER_NAME_PREFIX = "bay-"
 
 
 class OrphanContainerGC(GCTask):
@@ -50,7 +50,7 @@ class OrphanContainerGC(GCTask):
 
     STRICT MODE (default and only mode):
         Only containers meeting ALL of the following criteria are deleted:
-        1. Name starts with "bay-session-"
+        1. Name starts with "bay-"
         2. Has all required labels
         3. bay.managed = "true"
         4. bay.instance_id = configured gc.instance_id
@@ -125,7 +125,7 @@ class OrphanContainerGC(GCTask):
                 "gc.orphan_container.skip.name_prefix",
                 instance_id=instance.id,
                 instance_name=instance.name,
-                reason="name does not start with bay-session-",
+                reason="name does not start with bay-",
             )
             result.skipped_count += 1
             return False


### PR DESCRIPTION
动机:OrphanContainerGC 严格校验容器名称必须以 bay-session- 开头，但 Phase 2 多容器 sandbox 的容器命名格式为 bay-{session.id}-{spec.name}（例如 bay-sess-abc-browser）。这导致所有多容器（及 browser/multi-container）sandbox 产生的孤儿容器被 GC 跳过，日志持续输出：
解决方案
将 CONTAINER_NAME_PREFIX 从 "bay-session-" 放宽为 "bay-"。
改动依据：
OrphanContainerGC 已有额外的严格校验机制，无需依赖容器名称前缀来保障安全：
1. bay.managed="true" 标签过滤（Discovery 阶段）
2. bay.instance_id 匹配当前 GC 实例
3. 所有必需标签存在性检查
4. bay.session_id 在数据库中不存在才执行删除
因此放宽名称前缀不会影响安全性，且能正确覆盖两种命名格式：
- 单容器：bay-session-{id}
- 多容器：bay-{id}-{spec.name}

## Summary by Sourcery

Bug Fixes:
- Ensure orphan container GC also cleans up containers named with the new multi-container pattern starting with "bay-" instead of only "bay-session-".