### PR TITLE
新增GULL_CHROMIUM_ARGS选项，允许用户自定义无头浏览器的启动参数

### DIFF
--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -28,6 +28,7 @@ services:
       - GULL_MODE=shared
       - GULL_CDP_PORT=9222
       - AGENT_BROWSER_IDLE_TIMEOUT_MS=600000  # 10 min session GC
+      # - GULL_CHROMIUM_ARGS=--user-agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36" #custom user-agent
     volumes:
       - ./bay-cargos:/cargos:ro
     networks:

--- a/pkgs/gull/app/session.py
+++ b/pkgs/gull/app/session.py
@@ -82,9 +82,19 @@ CHROMIUM_ARGS = [
 ]
 
 CUSTOM_ARGS = os.environ.get("GULL_CHROMIUM_ARGS")
-
 if CUSTOM_ARGS:
-    CHROMIUM_ARGS.extend(shlex.split(CUSTOM_ARGS))
+    try:
+        custom_args = shlex.split(CUSTOM_ARGS)
+        CHROMIUM_ARGS.extend(custom_args)
+        logger.info("[gull] Applied Chromium args: %s", custom_args)
+    except ValueError as e:
+        logger.exception(
+            "[gull] Invalid GULL_CHROMIUM_ARGS: '%s' — %s. Ignoring custom args.",
+            CUSTOM_ARGS,
+            e
+        )
+
+logger.info("[gull] Final Chromium arguments: %s", CHROMIUM_ARGS)
 
 _chromium: asyncio.subprocess.Process | None = None
 _chromium_lock: asyncio.Lock = asyncio.Lock()

--- a/pkgs/gull/app/session.py
+++ b/pkgs/gull/app/session.py
@@ -81,6 +81,11 @@ CHROMIUM_ARGS = [
     f"--remote-debugging-port={CDP_PORT}",
 ]
 
+CUSTOM_ARGS = os.environ.get("GULL_CHROMIUM_ARGS")
+
+if CUSTOM_ARGS:
+    CHROMIUM_ARGS.extend(shlex.split(CUSTOM_ARGS))
+
 _chromium: asyncio.subprocess.Process | None = None
 _chromium_lock: asyncio.Lock = asyncio.Lock()
 


### PR DESCRIPTION
原先的gull使用默认的chrome启动参数，导致bot在访问部分论坛等网站时因为默认的HeadlessChrome user-agent从而被风控拦截
该选项允许用户自定义浏览器的启动参数，从而实现部分自定义功能，包括浏览器的ua

## Summary by Sourcery

Add support for custom Chromium launch arguments via environment variable to allow overriding default headless browser behavior.

New Features:
- Introduce a GULL_CHROMIUM_ARGS environment variable to append custom launch arguments to the Chromium process, enabling user-agent and other browser customizations.

Build:
- Document optional GULL_CHROMIUM_ARGS usage in docker-compose to demonstrate setting a custom user agent.