### PR TITLE
fix(bay): 修复预热沙盒卡住与多容器误判

### DIFF
--- a/pkgs/bay/app/drivers/k8s/k8s.py
+++ b/pkgs/bay/app/drivers/k8s/k8s.py
@@ -617,7 +617,7 @@ class K8sDriver(Driver):
             )
         except ApiException:
             self._log.exception("k8s.list_runtime_instances.failed")
-            return []
+            raise
 
         instances = []
         for pod in pod_list.items:
@@ -692,8 +692,7 @@ class K8sDriver(Driver):
             await asyncio.sleep(1)
 
         raise RuntimeError(
-            f"Pod {instance_id} was not deleted within "
-            f"{self._pod_startup_timeout} seconds"
+            f"Pod {instance_id} was not deleted within {self._pod_startup_timeout} seconds"
         )
 
     # ================================================================

--- a/pkgs/bay/app/drivers/k8s/k8s.py
+++ b/pkgs/bay/app/drivers/k8s/k8s.py
@@ -670,8 +670,31 @@ class K8sDriver(Driver):
                     "k8s.destroy_runtime_instance.not_found",
                     pod_name=instance_id,
                 )
+                return
             else:
                 raise
+
+        for _ in range(self._pod_startup_timeout):
+            try:
+                await v1.read_namespaced_pod(
+                    name=instance_id,
+                    namespace=self._namespace,
+                )
+            except ApiException as e:
+                if e.status == 404:
+                    self._log.info(
+                        "k8s.destroy_runtime_instance.deleted",
+                        pod_name=instance_id,
+                    )
+                    return
+                raise
+
+            await asyncio.sleep(1)
+
+        raise RuntimeError(
+            f"Pod {instance_id} was not deleted within "
+            f"{self._pod_startup_timeout} seconds"
+        )
 
     # ================================================================
     # Phase 2: Multi-container orchestration (Sidecar pattern)

--- a/pkgs/bay/app/managers/sandbox/sandbox.py
+++ b/pkgs/bay/app/managers/sandbox/sandbox.py
@@ -14,6 +14,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING
 
 import structlog
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -834,7 +835,11 @@ class SandboxManager:
 
         return sandbox
 
-    async def mark_warm_available(self, sandbox_id: str, warm_rotate_ttl: int = 1800) -> None:
+    async def mark_warm_available(
+        self,
+        sandbox_id: str,
+        warm_rotate_ttl: int = 1800,
+    ) -> bool:
         """Mark a warm sandbox as available (warmup completed).
 
         Called by the warmup queue worker after successful ensure_running().
@@ -842,33 +847,41 @@ class SandboxManager:
         Args:
             sandbox_id: Sandbox ID to mark
             warm_rotate_ttl: Seconds until rotation
+
+        Returns:
+            True when a pending warm sandbox was marked available.
         """
         now = utcnow()
+        rotate_at = now + timedelta(seconds=warm_rotate_ttl)
         result = await self._db.execute(
-            select(Sandbox).where(
+            update(Sandbox)
+            .where(
                 Sandbox.id == sandbox_id,
+                Sandbox.deleted_at.is_(None),
                 Sandbox.is_warm_pool.is_(True),
+                Sandbox.warm_state.is_(None),
+            )
+            .values(
+                warm_state=WarmState.AVAILABLE.value,
+                warm_ready_at=now,
+                warm_rotate_at=rotate_at,
             )
         )
-        sandbox = result.scalars().first()
+        await self._db.commit()
 
-        if sandbox is None:
-            self._log.warning(
-                "sandbox.mark_warm_available.not_found",
+        if result.rowcount != 1:
+            self._log.debug(
+                "sandbox.mark_warm_available.skipped",
                 sandbox_id=sandbox_id,
             )
-            return
-
-        sandbox.warm_state = WarmState.AVAILABLE.value
-        sandbox.warm_ready_at = now
-        sandbox.warm_rotate_at = now + timedelta(seconds=warm_rotate_ttl)
-        await self._db.commit()
+            return False
 
         self._log.info(
             "sandbox.warm_available",
             sandbox_id=sandbox_id,
-            warm_rotate_at=sandbox.warm_rotate_at.isoformat(),
+            warm_rotate_at=rotate_at.isoformat(),
         )
+        return True
 
     async def mark_warm_retiring(self, sandbox_id: str) -> None:
         """Mark a warm sandbox as retiring (prevent it from being claimed).

--- a/pkgs/bay/app/managers/session/session.py
+++ b/pkgs/bay/app/managers/session/session.py
@@ -149,27 +149,31 @@ class SessionManager:
 
         Backward compatible with existing single-container profiles.
         """
+        recovered_endpoint: str | None = None
+
         # Phase 1.5: Proactive health probing
         # If DB says RUNNING but container might be dead, probe before trusting
         if session.container_id is not None and session.observed_state == SessionStatus.RUNNING:
             session = await self._probe_and_recover_if_dead(session, cargo, profile)
 
+        # A process restart can leave the persisted state at STARTING after the
+        # runtime was created or even became healthy. Resume that transition
+        # instead of treating it as an in-process concurrent start.
+        if session.observed_state == SessionStatus.STARTING:
+            session, recovered_endpoint = await self._recover_starting_single(
+                session,
+                profile,
+            )
+
         # Already running and ready (after probe)
         if session.is_ready:
             return session
-
-        # Currently starting - tell client to retry
-        if session.observed_state == SessionStatus.STARTING:
-            raise SessionNotReadyError(
-                message="Session is starting",
-                sandbox_id=session.sandbox_id,
-                retry_after_ms=1000,
-            )
 
         # Need to create container
         if session.container_id is None:
             session.desired_state = SessionStatus.RUNNING
             session.observed_state = SessionStatus.STARTING
+            session.last_observed_at = utcnow()
             await self._db.commit()
 
             try:
@@ -199,10 +203,12 @@ class SessionManager:
             primary = profile.get_primary_container()
             runtime_port = primary.runtime_port if primary else 8123
             try:
-                endpoint = await self._driver.start(
-                    container_id,
-                    runtime_port=runtime_port,
-                )
+                endpoint = recovered_endpoint
+                if endpoint is None:
+                    endpoint = await self._driver.start(
+                        container_id,
+                        runtime_port=runtime_port,
+                    )
 
                 # Wait for runtime to be ready before marking as RUNNING.
                 # For browser containers (Gull), also checks that browser_ready=true
@@ -238,6 +244,15 @@ class SessionManager:
                             container_id=container_id,
                             error=str(destroy_error),
                         )
+                        session.endpoint = None
+                        session.observed_state = SessionStatus.FAILED
+                        session.last_observed_at = utcnow()
+                        await self._db.commit()
+                        raise SessionNotReadyError(
+                            message="Single-container cleanup is incomplete",
+                            sandbox_id=session.sandbox_id,
+                            retry_after_ms=1000,
+                        ) from destroy_error
                 session.container_id = None
                 session.endpoint = None
                 session.observed_state = SessionStatus.FAILED
@@ -271,13 +286,24 @@ class SessionManager:
                 primary_container_id=session.container_id,
                 container_names=[c.get("name") for c in session.containers],
             )
-            session = await self._probe_and_recover_multi_if_dead(session)
+            session, _runtime_group_healthy = await self._probe_and_recover_multi_if_dead(session)
 
         # Already running and ready
         if session.is_ready:
             return session
 
-        # Currently starting - tell client to retry
+        # A multi-container transition only persists its complete runtime map
+        # after every member is ready. If startup was interrupted, discard the
+        # incomplete runtime group before rebuilding it.
+        if session.observed_state == SessionStatus.STARTING:
+            session, runtime_group_healthy = await self._probe_and_recover_multi_if_dead(session)
+            if runtime_group_healthy and session.containers:
+                session = await self._finish_starting_multi(session, profile)
+
+        if session.is_ready:
+            return session
+
+        # Runtime discovery failures are handled conservatively.
         if session.observed_state == SessionStatus.STARTING:
             raise SessionNotReadyError(
                 message="Session is starting (multi-container)",
@@ -389,6 +415,168 @@ class SessionManager:
                 raise
 
         return session
+
+    async def _finish_starting_multi(
+        self,
+        session: Session,
+        profile: ProfileConfig,
+    ) -> Session:
+        """Finish a persisted multi-container transition whose runtimes survived."""
+        container_infos = [
+            MultiContainerInfo(
+                name=container["name"],
+                container_id=container["container_id"],
+                endpoint=container.get("endpoint"),
+                status=ContainerStatus.RUNNING,
+                runtime_type=container.get("runtime_type", "ship"),
+                capabilities=container.get("capabilities", []),
+            )
+            for container in session.containers or []
+        ]
+
+        await self._wait_for_multi_ready(
+            container_infos,
+            session_id=session.id,
+            sandbox_id=session.sandbox_id,
+        )
+
+        primary_spec = profile.get_primary_container()
+        primary_name = primary_spec.name if primary_spec else container_infos[0].name
+        primary_info = next(
+            (container for container in container_infos if container.name == primary_name),
+            container_infos[0],
+        )
+        if primary_info.endpoint is None:
+            raise SessionNotReadyError(
+                message="Primary container endpoint is unavailable",
+                sandbox_id=session.sandbox_id,
+                retry_after_ms=1000,
+            )
+
+        session.container_id = primary_info.container_id
+        session.endpoint = primary_info.endpoint
+        session.observed_state = SessionStatus.RUNNING
+        session.last_observed_at = utcnow()
+        await self._db.commit()
+
+        self._log.info(
+            "session.multi_starting_recovered",
+            session_id=session.id,
+            sandbox_id=session.sandbox_id,
+            primary_container_id=primary_info.container_id,
+            primary_endpoint=primary_info.endpoint,
+            container_ids=[container.container_id for container in container_infos],
+        )
+        return session
+
+    async def _recover_starting_single(
+        self,
+        session: Session,
+        profile: ProfileConfig,
+    ) -> tuple[Session, str | None]:
+        """Resume or reset a single-container STARTING transition."""
+        container_id = session.container_id
+        if container_id is None:
+            session.endpoint = None
+            session.observed_state = SessionStatus.PENDING
+            session.last_observed_at = utcnow()
+            await self._db.commit()
+            self._log.info(
+                "session.starting_recovered_before_create",
+                session_id=session.id,
+                sandbox_id=session.sandbox_id,
+            )
+            return session, None
+
+        primary = profile.get_primary_container()
+        runtime_port = primary.runtime_port if primary else 8123
+        try:
+            info = await self._driver.status(
+                container_id,
+                runtime_port=runtime_port,
+            )
+        except Exception as exc:
+            self._log.warning(
+                "session.starting_probe_failed",
+                session_id=session.id,
+                sandbox_id=session.sandbox_id,
+                container_id=container_id,
+                error=str(exc),
+            )
+            raise SessionNotReadyError(
+                message="Session is starting",
+                sandbox_id=session.sandbox_id,
+                retry_after_ms=1000,
+            ) from exc
+
+        if info.status == ContainerStatus.RUNNING:
+            if info.endpoint is None:
+                self._log.warning(
+                    "session.starting_runtime_endpoint_missing",
+                    session_id=session.id,
+                    sandbox_id=session.sandbox_id,
+                    container_id=container_id,
+                )
+                raise SessionNotReadyError(
+                    message="Session is starting",
+                    sandbox_id=session.sandbox_id,
+                    retry_after_ms=1000,
+                )
+
+            self._log.info(
+                "session.starting_runtime_running",
+                session_id=session.id,
+                sandbox_id=session.sandbox_id,
+                container_id=container_id,
+                endpoint=info.endpoint,
+            )
+            return session, info.endpoint
+
+        if info.status == ContainerStatus.CREATED:
+            self._log.info(
+                "session.starting_runtime_created",
+                session_id=session.id,
+                sandbox_id=session.sandbox_id,
+                container_id=container_id,
+            )
+            return session, None
+
+        self._log.warning(
+            "session.starting_runtime_unhealthy",
+            session_id=session.id,
+            sandbox_id=session.sandbox_id,
+            container_id=container_id,
+            container_status=info.status.value,
+        )
+        try:
+            await self._driver.destroy(container_id)
+        except Exception as destroy_error:
+            self._log.warning(
+                "session.starting_runtime_destroy_failed",
+                session_id=session.id,
+                sandbox_id=session.sandbox_id,
+                container_id=container_id,
+                error=str(destroy_error),
+            )
+            raise SessionNotReadyError(
+                message="Single-container cleanup is incomplete",
+                sandbox_id=session.sandbox_id,
+                retry_after_ms=1000,
+            ) from destroy_error
+
+        session.container_id = None
+        session.endpoint = None
+        session.observed_state = SessionStatus.PENDING
+        session.last_observed_at = utcnow()
+        await self._db.commit()
+
+        self._log.info(
+            "session.starting_recovered_from_dead_runtime",
+            session_id=session.id,
+            sandbox_id=session.sandbox_id,
+            old_container_id=container_id,
+        )
+        return session, None
 
     async def _wait_for_multi_ready(
         self,
@@ -750,7 +938,10 @@ class SessionManager:
             session.last_active_at = utcnow()
             await self._db.commit()
 
-    async def _probe_and_recover_multi_if_dead(self, session: Session) -> Session:
+    async def _probe_and_recover_multi_if_dead(
+        self,
+        session: Session,
+    ) -> tuple[Session, bool]:
         """Probe multi-container runtime presence and reset stale session state.
 
         For multi-container sessions, the DB may still say RUNNING even after the
@@ -776,7 +967,7 @@ class SessionManager:
                 expected_container_ids=expected_container_ids,
                 error=str(e),
             )
-            return session
+            return session, False
 
         live_instances = [
             instance for instance in instances if instance.state == ContainerStatus.RUNNING.value
@@ -804,7 +995,7 @@ class SessionManager:
                 sandbox_id=session.sandbox_id,
                 live_runtime_ids=[instance.id for instance in live_instances],
             )
-            return session
+            return session, True
 
         expected_container_ids_set = {
             container_id
@@ -891,7 +1082,7 @@ class SessionManager:
             old_endpoint=old_endpoint,
             reset_observed_state=session.observed_state,
         )
-        return session
+        return session, False
 
     async def _probe_and_recover_if_dead(
         self,
@@ -952,12 +1143,17 @@ class SessionManager:
         try:
             await self._driver.destroy(container_id)
         except Exception as destroy_error:
-            self._log.debug(
+            self._log.warning(
                 "session.destroy_dead_container_failed",
                 session_id=session.id,
                 container_id=container_id,
                 error=str(destroy_error),
             )
+            raise SessionNotReadyError(
+                message="Single-container cleanup is incomplete",
+                sandbox_id=session.sandbox_id,
+                retry_after_ms=1000,
+            ) from destroy_error
 
         # Clear runtime fields and reset to PENDING for rebuild
         session.container_id = None

--- a/pkgs/bay/app/managers/session/session.py
+++ b/pkgs/bay/app/managers/session/session.py
@@ -27,6 +27,7 @@ from app.models.cargo import Cargo
 from app.models.session import Session, SessionStatus
 from app.services.http import http_client_manager
 from app.utils.datetime import utcnow
+from app.utils.runtime_health import all_expected_runtimes_running
 
 logger = structlog.get_logger()
 
@@ -792,8 +793,11 @@ class SessionManager:
             live_runtime_count=len(live_instances),
         )
 
-        has_live_runtime = len(live_instances) > 0
-        if has_live_runtime:
+        runtime_group_healthy = all_expected_runtimes_running(
+            session.containers or [],
+            instances,
+        )
+        if runtime_group_healthy:
             self._log.debug(
                 "session.multi_probe.healthy",
                 session_id=session.id,
@@ -802,14 +806,73 @@ class SessionManager:
             )
             return session
 
+        expected_container_ids_set = {
+            container_id
+            for container_id in expected_container_ids
+            if isinstance(container_id, str) and container_id
+        }
+        live_runtime_ids = {instance.id for instance in live_instances}
         self._log.warning(
-            "session.multi_runtime_dead_detected",
+            "session.multi_runtime_unhealthy_detected",
             session_id=session.id,
             sandbox_id=session.sandbox_id,
             expected_container_names=expected_container_names,
             expected_container_ids=expected_container_ids,
+            missing_runtime_ids=sorted(expected_container_ids_set - live_runtime_ids),
             runtime_count=len(instances),
         )
+
+        cleanup_failures: list[dict[str, str]] = []
+        for instance in instances:
+            try:
+                await self._driver.destroy_runtime_instance(instance.id)
+            except Exception as cleanup_error:
+                cleanup_failures.append(
+                    {
+                        "operation": "destroy_runtime",
+                        "resource_id": instance.id,
+                        "error": str(cleanup_error),
+                    }
+                )
+                self._log.warning(
+                    "session.multi_recovery.destroy_runtime_failed",
+                    session_id=session.id,
+                    sandbox_id=session.sandbox_id,
+                    runtime_id=instance.id,
+                    runtime_name=instance.name,
+                    runtime_state=instance.state,
+                    error=str(cleanup_error),
+                )
+
+        try:
+            await self._driver.remove_session_network(session.id)
+        except Exception as cleanup_error:
+            cleanup_failures.append(
+                {
+                    "operation": "remove_network",
+                    "resource_id": session.id,
+                    "error": str(cleanup_error),
+                }
+            )
+            self._log.warning(
+                "session.multi_recovery.remove_network_failed",
+                session_id=session.id,
+                sandbox_id=session.sandbox_id,
+                error=str(cleanup_error),
+            )
+
+        if cleanup_failures:
+            self._log.warning(
+                "session.multi_recovery.cleanup_incomplete",
+                session_id=session.id,
+                sandbox_id=session.sandbox_id,
+                failures=cleanup_failures,
+            )
+            raise SessionNotReadyError(
+                message="Multi-container cleanup is incomplete",
+                sandbox_id=session.sandbox_id,
+                retry_after_ms=1000,
+            )
 
         old_primary_container_id = session.container_id
         old_endpoint = session.endpoint

--- a/pkgs/bay/app/services/warm_pool/queue.py
+++ b/pkgs/bay/app/services/warm_pool/queue.py
@@ -320,24 +320,28 @@ class WarmupQueue:
                     warm_state=sandbox.warm_state,
                 )
 
-                # If this is a warm pool sandbox, mark it as available after warmup
-                if sandbox.is_warm_pool and sandbox.warm_state is None:
+                # The scheduler may reset warm_state in another DB session while
+                # ensure_running() is recovering the runtime. Let the manager
+                # perform a conditional database transition instead of trusting
+                # this session's potentially stale ORM object.
+                if sandbox.is_warm_pool:
                     from app.config import get_settings
 
                     settings = get_settings()
                     profile = settings.get_profile(sandbox.profile_id)
                     warm_rotate_ttl = profile.warm_rotate_ttl if profile else 1800
-                    await manager.mark_warm_available(
+                    marked_available = await manager.mark_warm_available(
                         sandbox.id,
                         warm_rotate_ttl=warm_rotate_ttl,
                     )
-                    self._log.info(
-                        "warmup_worker.mark_available.complete",
-                        worker_id=worker_id,
-                        sandbox_id=sandbox.id,
-                        profile_id=sandbox.profile_id,
-                        warm_rotate_ttl=warm_rotate_ttl,
-                    )
+                    if marked_available:
+                        self._log.info(
+                            "warmup_worker.mark_available.complete",
+                            worker_id=worker_id,
+                            sandbox_id=sandbox.id,
+                            profile_id=sandbox.profile_id,
+                            warm_rotate_ttl=warm_rotate_ttl,
+                        )
 
             self._stats.success_total += 1
             self._log.info(

--- a/pkgs/bay/app/services/warm_pool/scheduler.py
+++ b/pkgs/bay/app/services/warm_pool/scheduler.py
@@ -17,8 +17,9 @@ from sqlmodel import func, select
 
 from app.drivers.base import ContainerStatus
 from app.models.sandbox import Sandbox, WarmState
-from app.models.session import Session, SessionStatus
+from app.models.session import Session
 from app.utils.datetime import utcnow
+from app.utils.runtime_health import all_expected_runtimes_running
 
 if TYPE_CHECKING:
     from app.config import WarmPoolConfig
@@ -136,10 +137,9 @@ class WarmPoolScheduler:
     async def _reconcile_profile_runtime_state(self, profile_id: str) -> int:
         """Reconcile DB warm-pool state with actual runtime state.
 
-        For warm sandboxes marked as available, the DB may drift from reality after
-        driver/runtime restarts. This periodically re-validates those rows against
-        the runtime backend and downgrades broken entries back to pending so they
-        can be re-enqueued for warmup.
+        Available sandboxes are re-validated against the runtime backend. Pending
+        sandboxes are periodically submitted to the deduplicating warmup queue so
+        a task that failed after leaving the queue cannot block replenishment.
 
         Returns:
             Number of warm sandboxes requeued for recovery.
@@ -154,88 +154,95 @@ class WarmPoolScheduler:
                 .where(
                     Sandbox.deleted_at.is_(None),
                     Sandbox.is_warm_pool.is_(True),
-                    Sandbox.warm_state == WarmState.AVAILABLE.value,
                     Sandbox.profile_id == profile_id,
                 )
             )
-            available_rows = result.all()
+            warm_rows = result.all()
 
-        if not available_rows:
+        available_rows = [
+            (sandbox, session)
+            for sandbox, session in warm_rows
+            if sandbox.warm_state == WarmState.AVAILABLE.value
+        ]
+        pending_rows = [
+            (sandbox, session) for sandbox, session in warm_rows if sandbox.warm_state is None
+        ]
+
+        if not available_rows and not pending_rows:
             return 0
 
-        driver = get_driver()
         stale_ids: list[str] = []
-        requeued = 0
+        if available_rows:
+            driver = get_driver()
+            for sandbox, session in available_rows:
+                runtime_ok = False
 
-        for sandbox, session in available_rows:
-            runtime_ok = False
+                if session is not None:
+                    runtime_ok = await self._is_session_runtime_healthy(driver, session)
 
-            if session is not None:
-                runtime_ok = await self._is_session_runtime_healthy(driver, session)
+                if runtime_ok:
+                    self._log.debug(
+                        "warm_pool.runtime_state_healthy",
+                        sandbox_id=sandbox.id,
+                        profile_id=profile_id,
+                        session_id=sandbox.current_session_id,
+                        current_session_id=sandbox.current_session_id,
+                        warm_state=sandbox.warm_state,
+                    )
+                    continue
 
-            if runtime_ok:
-                self._log.debug(
-                    "warm_pool.runtime_state_healthy",
+                stale_ids.append(sandbox.id)
+                self._log.warning(
+                    "warm_pool.runtime_state_drift_detected",
                     sandbox_id=sandbox.id,
                     profile_id=profile_id,
                     session_id=sandbox.current_session_id,
                     current_session_id=sandbox.current_session_id,
                     warm_state=sandbox.warm_state,
                 )
-                continue
 
-            stale_ids.append(sandbox.id)
-            enqueue_result = self._queue.enqueue(sandbox_id=sandbox.id, owner=sandbox.owner)
+        stale_owners: dict[str, str] = {}
+        if stale_ids:
+            async with get_async_session() as db:
+                result = await db.execute(
+                    select(Sandbox).where(
+                        Sandbox.id.in_(stale_ids),
+                        Sandbox.deleted_at.is_(None),
+                        Sandbox.is_warm_pool.is_(True),
+                        Sandbox.warm_state == WarmState.AVAILABLE.value,
+                    )
+                )
+                stale_sandboxes = result.scalars().all()
+
+                for sandbox in stale_sandboxes:
+                    sandbox.warm_state = None
+                    sandbox.warm_ready_at = None
+                    sandbox.warm_rotate_at = None
+                    stale_owners[sandbox.id] = sandbox.owner
+
+                await db.commit()
+
+        recovery_refs = {sandbox.id: sandbox.owner for sandbox, _session in pending_rows}
+        recovery_refs.update(stale_owners)
+
+        requeued = 0
+        for sandbox_id, owner in recovery_refs.items():
+            enqueue_result = self._queue.enqueue(sandbox_id=sandbox_id, owner=owner)
             if enqueue_result:
                 requeued += 1
 
-            self._log.warning(
-                "warm_pool.runtime_state_drift_detected",
-                sandbox_id=sandbox.id,
+            self._log.debug(
+                "warm_pool.requeue_result",
+                sandbox_id=sandbox_id,
                 profile_id=profile_id,
-                session_id=sandbox.current_session_id,
-                current_session_id=sandbox.current_session_id,
-                warm_state=sandbox.warm_state,
                 requeued=enqueue_result,
             )
-
-        if not stale_ids:
-            return 0
-
-        async with get_async_session() as db:
-            result = await db.execute(select(Sandbox).where(Sandbox.id.in_(stale_ids)))
-            stale_sandboxes = result.scalars().all()
-
-            session_ids = [
-                sandbox.current_session_id
-                for sandbox in stale_sandboxes
-                if sandbox.current_session_id
-            ]
-            sessions_by_id: dict[str, Session] = {}
-            if session_ids:
-                session_result = await db.execute(
-                    select(Session).where(Session.id.in_(session_ids))
-                )
-                sessions_by_id = {session.id: session for session in session_result.scalars().all()}
-
-            for sandbox in stale_sandboxes:
-                sandbox.warm_state = None
-                sandbox.warm_ready_at = None
-                sandbox.warm_rotate_at = None
-
-                if sandbox.current_session_id:
-                    session = sessions_by_id.get(sandbox.current_session_id)
-                    if session is not None:
-                        session.observed_state = SessionStatus.STOPPED
-                        session.endpoint = None
-                        session.last_observed_at = utcnow()
-
-            await db.commit()
 
         self._log.info(
             "warm_pool.runtime_reconcile.complete",
             profile_id=profile_id,
-            checked=len(available_rows),
+            checked_available=len(available_rows),
+            pending=len(pending_rows),
             stale=len(stale_ids),
             requeued=requeued,
         )
@@ -263,7 +270,7 @@ class WarmPoolScheduler:
                 )
                 return True
 
-            healthy = any(instance.state == ContainerStatus.RUNNING.value for instance in instances)
+            healthy = all_expected_runtimes_running(session.containers, instances)
             self._log.debug(
                 "warm_pool.runtime_probe_result",
                 session_id=session.id,

--- a/pkgs/bay/app/services/warm_pool/scheduler.py
+++ b/pkgs/bay/app/services/warm_pool/scheduler.py
@@ -17,7 +17,7 @@ from sqlmodel import func, select
 
 from app.drivers.base import ContainerStatus
 from app.models.sandbox import Sandbox, WarmState
-from app.models.session import Session
+from app.models.session import Session, SessionStatus
 from app.utils.datetime import utcnow
 from app.utils.runtime_health import all_expected_runtimes_running
 
@@ -138,8 +138,9 @@ class WarmPoolScheduler:
         """Reconcile DB warm-pool state with actual runtime state.
 
         Available sandboxes are re-validated against the runtime backend. Pending
-        sandboxes are periodically submitted to the deduplicating warmup queue so
-        a task that failed after leaving the queue cannot block replenishment.
+        sandboxes without an active session, or with a failed/stopped session, are
+        submitted to the deduplicating warmup queue so a failed task cannot block
+        replenishment.
 
         Returns:
             Number of warm sandboxes requeued for recovery.
@@ -165,7 +166,13 @@ class WarmPoolScheduler:
             if sandbox.warm_state == WarmState.AVAILABLE.value
         ]
         pending_rows = [
-            (sandbox, session) for sandbox, session in warm_rows if sandbox.warm_state is None
+            (sandbox, session)
+            for sandbox, session in warm_rows
+            if sandbox.warm_state is None
+            and (
+                session is None
+                or session.observed_state in (SessionStatus.FAILED, SessionStatus.STOPPED)
+            )
         ]
 
         if not available_rows and not pending_rows:

--- a/pkgs/bay/app/utils/runtime_health.py
+++ b/pkgs/bay/app/utils/runtime_health.py
@@ -1,0 +1,29 @@
+"""Helpers for evaluating persisted multi-container runtime groups."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+from app.drivers.base import ContainerStatus, RuntimeInstance
+
+
+def all_expected_runtimes_running(
+    expected_containers: Iterable[Mapping[str, object]],
+    instances: Iterable[RuntimeInstance],
+) -> bool:
+    """Return whether every distinct persisted runtime is currently running."""
+    expected_containers = list(expected_containers)
+    if not expected_containers:
+        return False
+
+    expected_ids: set[str] = set()
+    for container in expected_containers:
+        container_id = container.get("container_id")
+        if not isinstance(container_id, str) or not container_id:
+            return False
+        expected_ids.add(container_id)
+
+    running_ids = {
+        instance.id for instance in instances if instance.state == ContainerStatus.RUNNING.value
+    }
+    return expected_ids.issubset(running_ids)

--- a/pkgs/bay/tests/unit/drivers/test_k8s_driver.py
+++ b/pkgs/bay/tests/unit/drivers/test_k8s_driver.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from kubernetes_asyncio.client import ApiException
 
 from app.drivers.base import ContainerStatus
 from app.drivers.k8s.k8s import K8sDriver, _parse_memory, _parse_storage_size
@@ -282,6 +283,55 @@ class TestK8sDriverListRuntimeInstances:
                 instances = await driver.list_runtime_instances(labels={"bay.managed": "true"})
 
                 assert len(instances) == 0
+
+
+class TestK8sDriverDestroyRuntimeInstance:
+    """Test that Pod deletion is complete before a same-name rebuild."""
+
+    @pytest.fixture
+    def driver(self):
+        with patch("app.drivers.k8s.k8s.get_settings") as mock_settings:
+            mock_k8s_cfg = MagicMock()
+            mock_k8s_cfg.namespace = "bay"
+            mock_k8s_cfg.kubeconfig = None
+            mock_k8s_cfg.storage_class = None
+            mock_k8s_cfg.default_storage_size = "1Gi"
+            mock_k8s_cfg.image_pull_secrets = []
+            mock_k8s_cfg.pod_startup_timeout = 2
+            mock_k8s_cfg.label_prefix = "bay"
+
+            mock_driver_cfg = MagicMock()
+            mock_driver_cfg.k8s = mock_k8s_cfg
+            mock_settings.return_value.driver = mock_driver_cfg
+
+            return K8sDriver()
+
+    @pytest.mark.asyncio
+    async def test_destroy_waits_until_pod_is_absent(self, driver):
+        mock_v1 = AsyncMock()
+        mock_v1.read_namespaced_pod.side_effect = [
+            MagicMock(),
+            ApiException(status=404),
+        ]
+
+        with patch.object(driver, "_get_api_client", return_value=MagicMock()):
+            with patch("app.drivers.k8s.k8s.client.CoreV1Api", return_value=mock_v1):
+                with patch("app.drivers.k8s.k8s.asyncio.sleep", new=AsyncMock()):
+                    await driver.destroy_runtime_instance("bay-session-test")
+
+        mock_v1.delete_namespaced_pod.assert_awaited_once()
+        assert mock_v1.read_namespaced_pod.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_destroy_raises_when_pod_does_not_disappear(self, driver):
+        mock_v1 = AsyncMock()
+        mock_v1.read_namespaced_pod.return_value = MagicMock()
+
+        with patch.object(driver, "_get_api_client", return_value=MagicMock()):
+            with patch("app.drivers.k8s.k8s.client.CoreV1Api", return_value=mock_v1):
+                with patch("app.drivers.k8s.k8s.asyncio.sleep", new=AsyncMock()):
+                    with pytest.raises(RuntimeError, match="was not deleted"):
+                        await driver.destroy_runtime_instance("bay-session-test")
 
 
 class TestK8sDriverVolumeOperations:

--- a/pkgs/bay/tests/unit/drivers/test_k8s_driver.py
+++ b/pkgs/bay/tests/unit/drivers/test_k8s_driver.py
@@ -284,6 +284,22 @@ class TestK8sDriverListRuntimeInstances:
 
                 assert len(instances) == 0
 
+    @pytest.mark.asyncio
+    async def test_list_runtime_instances_propagates_api_error(self, driver):
+        """A backend failure must not be reported as an empty runtime set."""
+        mock_v1 = AsyncMock()
+        mock_v1.list_namespaced_pod.side_effect = ApiException(
+            status=503,
+            reason="API unavailable",
+        )
+
+        with patch.object(driver, "_get_api_client") as mock_client:
+            with patch("app.drivers.k8s.k8s.client.CoreV1Api", return_value=mock_v1):
+                mock_client.return_value = MagicMock()
+
+                with pytest.raises(ApiException, match="API unavailable"):
+                    await driver.list_runtime_instances(labels={"bay.managed": "true"})
+
 
 class TestK8sDriverDestroyRuntimeInstance:
     """Test that Pod deletion is complete before a same-name rebuild."""

--- a/pkgs/bay/tests/unit/managers/test_session_manager.py
+++ b/pkgs/bay/tests/unit/managers/test_session_manager.py
@@ -9,7 +9,7 @@ and recovery).
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
@@ -126,6 +126,254 @@ class TestSessionManagerEnsureRunning:
         assert refreshed.endpoint is None
 
         assert driver.destroy_calls == ["fake-container-1"]
+
+    async def test_start_failure_preserves_container_reference_when_cleanup_fails(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        db_session: AsyncSession,
+        fake_settings: Settings,
+        profile: ProfileConfig,
+        cargo: Cargo,
+    ):
+        with patch("app.managers.session.session.get_settings", return_value=fake_settings):
+            driver = StartFailDriver()
+            manager = SessionManager(driver=driver, db_session=db_session)
+
+        sandbox = Sandbox(id="sandbox-start-cleanup", owner="test-user", profile_id=profile.id)
+        session = Session(
+            id="sess-start-cleanup",
+            sandbox_id=sandbox.id,
+            runtime_type="ship",
+            profile_id=profile.id,
+            desired_state=SessionStatus.PENDING,
+            observed_state=SessionStatus.PENDING,
+        )
+        db_session.add_all([sandbox, session])
+        await db_session.commit()
+        monkeypatch.setattr(
+            driver,
+            "destroy",
+            AsyncMock(side_effect=RuntimeError("cleanup failed")),
+        )
+        monkeypatch.setattr(manager, "_wait_for_ready", AsyncMock(return_value=None))
+
+        with pytest.raises(SessionNotReadyError, match="cleanup"):
+            await manager.ensure_running(session=session, cargo=cargo, profile=profile)
+
+        await db_session.refresh(session)
+        assert session.observed_state == SessionStatus.FAILED
+        assert session.container_id == "fake-container-1"
+        assert session.endpoint is None
+
+    async def test_recovers_starting_session_when_container_is_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        db_session: AsyncSession,
+        fake_settings: Settings,
+        profile: ProfileConfig,
+        cargo: Cargo,
+    ):
+        with patch("app.managers.session.session.get_settings", return_value=fake_settings):
+            driver = FakeDriver()
+            manager = SessionManager(driver=driver, db_session=db_session)
+
+        sandbox = Sandbox(id="sandbox-starting-missing", owner="test-user", profile_id=profile.id)
+        session = Session(
+            id="sess-starting-missing",
+            sandbox_id=sandbox.id,
+            runtime_type="ship",
+            profile_id=profile.id,
+            desired_state=SessionStatus.RUNNING,
+            observed_state=SessionStatus.STARTING,
+            container_id="missing-container",
+        )
+        db_session.add_all([sandbox, session])
+        await db_session.commit()
+
+        driver.set_status_override(
+            "missing-container",
+            ContainerInfo(
+                container_id="missing-container",
+                status=ContainerStatus.NOT_FOUND,
+            ),
+        )
+        monkeypatch.setattr(manager, "_wait_for_ready", AsyncMock(return_value=None))
+
+        result = await manager.ensure_running(session=session, cargo=cargo, profile=profile)
+
+        assert result.observed_state == SessionStatus.RUNNING
+        assert result.container_id == "fake-container-1"
+        assert result.endpoint == "http://fake-host:8123"
+        assert driver.destroy_calls == ["missing-container"]
+        assert len(driver.create_calls) == 1
+        assert driver.start_calls == [{"container_id": "fake-container-1", "runtime_port": 8123}]
+
+    async def test_resumes_starting_session_when_container_is_created(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        db_session: AsyncSession,
+        fake_settings: Settings,
+        profile: ProfileConfig,
+        cargo: Cargo,
+    ):
+        with patch("app.managers.session.session.get_settings", return_value=fake_settings):
+            driver = FakeDriver()
+            manager = SessionManager(driver=driver, db_session=db_session)
+
+        sandbox = Sandbox(id="sandbox-starting-created", owner="test-user", profile_id=profile.id)
+        session = Session(
+            id="sess-starting-created",
+            sandbox_id=sandbox.id,
+            runtime_type="ship",
+            profile_id=profile.id,
+            desired_state=SessionStatus.RUNNING,
+            observed_state=SessionStatus.STARTING,
+        )
+        db_session.add_all([sandbox, session])
+        await db_session.commit()
+
+        session.container_id = await driver.create(session=session, profile=profile, cargo=cargo)
+        driver.create_calls.clear()
+        await db_session.commit()
+        monkeypatch.setattr(manager, "_wait_for_ready", AsyncMock(return_value=None))
+
+        result = await manager.ensure_running(session=session, cargo=cargo, profile=profile)
+
+        assert result.observed_state == SessionStatus.RUNNING
+        assert result.container_id == "fake-container-1"
+        assert result.endpoint == "http://fake-host:8123"
+        assert driver.create_calls == []
+        assert driver.destroy_calls == []
+        assert driver.start_calls == [{"container_id": "fake-container-1", "runtime_port": 8123}]
+
+    async def test_finishes_starting_session_when_container_is_running(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        db_session: AsyncSession,
+        fake_settings: Settings,
+        profile: ProfileConfig,
+        cargo: Cargo,
+    ):
+        with patch("app.managers.session.session.get_settings", return_value=fake_settings):
+            driver = FakeDriver()
+            manager = SessionManager(driver=driver, db_session=db_session)
+
+        sandbox = Sandbox(id="sandbox-starting-running", owner="test-user", profile_id=profile.id)
+        session = Session(
+            id="sess-starting-running",
+            sandbox_id=sandbox.id,
+            runtime_type="ship",
+            profile_id=profile.id,
+            desired_state=SessionStatus.RUNNING,
+            observed_state=SessionStatus.STARTING,
+        )
+        db_session.add_all([sandbox, session])
+        await db_session.commit()
+
+        session.container_id = await driver.create(session=session, profile=profile, cargo=cargo)
+        await driver.start(session.container_id, runtime_port=8123)
+        driver.create_calls.clear()
+        driver.start_calls.clear()
+        await db_session.commit()
+        wait_for_ready = AsyncMock(return_value=None)
+        monkeypatch.setattr(manager, "_wait_for_ready", wait_for_ready)
+
+        result = await manager.ensure_running(session=session, cargo=cargo, profile=profile)
+
+        assert result.observed_state == SessionStatus.RUNNING
+        assert result.container_id == "fake-container-1"
+        assert result.endpoint == "http://fake-host:8123"
+        assert driver.create_calls == []
+        assert driver.start_calls == []
+        wait_for_ready.assert_awaited_once_with(
+            "http://fake-host:8123",
+            session_id=session.id,
+            sandbox_id=sandbox.id,
+            runtime_type=session.runtime_type,
+        )
+
+    async def test_keeps_starting_session_when_runtime_probe_fails(
+        self,
+        db_session: AsyncSession,
+        fake_settings: Settings,
+        profile: ProfileConfig,
+        cargo: Cargo,
+    ):
+        with patch("app.managers.session.session.get_settings", return_value=fake_settings):
+            driver = FakeDriver()
+            manager = SessionManager(driver=driver, db_session=db_session)
+
+        sandbox = Sandbox(
+            id="sandbox-starting-probe-error", owner="test-user", profile_id=profile.id
+        )
+        session = Session(
+            id="sess-starting-probe-error",
+            sandbox_id=sandbox.id,
+            runtime_type="ship",
+            profile_id=profile.id,
+            desired_state=SessionStatus.RUNNING,
+            observed_state=SessionStatus.STARTING,
+            container_id="unreachable-container",
+        )
+        db_session.add_all([sandbox, session])
+        await db_session.commit()
+        driver.set_status_exception(RuntimeError("docker unavailable"))
+
+        with pytest.raises(SessionNotReadyError, match="Session is starting"):
+            await manager.ensure_running(session=session, cargo=cargo, profile=profile)
+
+        await db_session.refresh(session)
+        assert session.observed_state == SessionStatus.STARTING
+        assert session.container_id == "unreachable-container"
+        assert driver.create_calls == []
+        assert driver.destroy_calls == []
+
+    async def test_preserves_starting_session_when_dead_container_cleanup_fails(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        db_session: AsyncSession,
+        fake_settings: Settings,
+        profile: ProfileConfig,
+        cargo: Cargo,
+    ):
+        with patch("app.managers.session.session.get_settings", return_value=fake_settings):
+            driver = FakeDriver()
+            manager = SessionManager(driver=driver, db_session=db_session)
+
+        sandbox = Sandbox(id="sandbox-starting-cleanup", owner="test-user", profile_id=profile.id)
+        session = Session(
+            id="sess-starting-cleanup",
+            sandbox_id=sandbox.id,
+            runtime_type="ship",
+            profile_id=profile.id,
+            desired_state=SessionStatus.RUNNING,
+            observed_state=SessionStatus.STARTING,
+            container_id="dead-container",
+        )
+        db_session.add_all([sandbox, session])
+        await db_session.commit()
+        driver.set_status_override(
+            "dead-container",
+            ContainerInfo(
+                container_id="dead-container",
+                status=ContainerStatus.NOT_FOUND,
+            ),
+        )
+        monkeypatch.setattr(
+            driver,
+            "destroy",
+            AsyncMock(side_effect=RuntimeError("cleanup failed")),
+        )
+        monkeypatch.setattr(manager, "_wait_for_ready", AsyncMock(return_value=None))
+
+        with pytest.raises(SessionNotReadyError, match="cleanup"):
+            await manager.ensure_running(session=session, cargo=cargo, profile=profile)
+
+        await db_session.refresh(session)
+        assert session.observed_state == SessionStatus.STARTING
+        assert session.container_id == "dead-container"
+        assert session.endpoint is None
+        assert driver.create_calls == []
 
     async def test_readiness_failure_destroys_container_does_not_persist_endpoint_and_sets_metadata(
         self,
@@ -378,6 +626,53 @@ class TestSessionManagerHealthProbing:
         assert result.observed_state == SessionStatus.RUNNING
         assert result.container_id is not None
         assert result.container_id != "vanished-container-1"
+
+    async def test_dead_container_cleanup_failure_preserves_runtime_reference(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        db_session: AsyncSession,
+        fake_settings: Settings,
+        profile: ProfileConfig,
+        cargo: Cargo,
+    ):
+        with patch("app.managers.session.session.get_settings", return_value=fake_settings):
+            driver = FakeDriver()
+            manager = SessionManager(driver=driver, db_session=db_session)
+
+        sandbox = Sandbox(id="sandbox-probe-cleanup", owner="test-user", profile_id=profile.id)
+        session = Session(
+            id="sess-probe-cleanup",
+            sandbox_id=sandbox.id,
+            runtime_type="ship",
+            profile_id=profile.id,
+            desired_state=SessionStatus.RUNNING,
+            observed_state=SessionStatus.RUNNING,
+            container_id="dead-container",
+            endpoint="http://dead-runtime:8123",
+        )
+        db_session.add_all([sandbox, session])
+        await db_session.commit()
+        driver.set_status_override(
+            "dead-container",
+            ContainerInfo(
+                container_id="dead-container",
+                status=ContainerStatus.EXITED,
+            ),
+        )
+        monkeypatch.setattr(
+            driver,
+            "destroy",
+            AsyncMock(side_effect=RuntimeError("cleanup failed")),
+        )
+        monkeypatch.setattr(manager, "_wait_for_ready", AsyncMock(return_value=None))
+
+        with pytest.raises(SessionNotReadyError, match="cleanup"):
+            await manager.ensure_running(session=session, cargo=cargo, profile=profile)
+
+        await db_session.refresh(session)
+        assert session.observed_state == SessionStatus.RUNNING
+        assert session.container_id == "dead-container"
+        assert session.endpoint == "http://dead-runtime:8123"
 
     async def test_ensure_running_degrades_gracefully_when_docker_unreachable(
         self,

--- a/pkgs/bay/tests/unit/managers/test_session_multi.py
+++ b/pkgs/bay/tests/unit/managers/test_session_multi.py
@@ -2,8 +2,8 @@
 
 Tests the _ensure_running_multi path for multi-container profiles.
 
-Note: We patch [`SessionManager._wait_for_multi_ready()`](pkgs/bay/app/managers/session/session.py:365)
-in unit tests because FakeDriver does not run a real HTTP server.
+Note: Unit tests patch `SessionManager._wait_for_multi_ready()` because
+FakeDriver does not run a real HTTP server.
 """
 
 from __future__ import annotations
@@ -14,6 +14,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import ContainerSpec, ProfileConfig
+from app.errors import SessionNotReadyError
 from app.managers.session.session import SessionManager
 from app.models.cargo import Cargo
 from app.models.session import Session, SessionStatus
@@ -79,8 +80,8 @@ def cargo() -> Cargo:
 def _patch_wait_for_ready_checks(monkeypatch: pytest.MonkeyPatch) -> None:
     """Avoid real HTTP calls in readiness checks.
 
-    - Multi-container uses [`SessionManager._wait_for_multi_ready()`](pkgs/bay/app/managers/session/session.py:365)
-    - Single-container uses [`SessionManager._wait_for_ready()`](pkgs/bay/app/managers/session/session.py:444)
+    - Multi-container uses `SessionManager._wait_for_multi_ready()`.
+    - Single-container uses `SessionManager._wait_for_ready()`.
 
     FakeDriver does not run a real HTTP server, so we patch both to no-op.
     """
@@ -223,7 +224,7 @@ class TestMultiContainerEnsureRunning:
     async def test_multi_container_recovers_when_runtime_group_was_deleted(
         self, driver: FakeDriver, db_session: AsyncSession, cargo: Cargo
     ):
-        """If the whole multi-container runtime group disappears, ensure_running should recreate it."""
+        """Recreate the multi-container runtime group when every runtime disappears."""
         from app.managers.session import SessionManager
 
         mgr = SessionManager(driver, db_session)
@@ -268,6 +269,125 @@ class TestMultiContainerEnsureRunning:
         # One initial create + one recovery create.
         assert len(driver.create_multi_calls) == 2
         assert len(driver.start_multi_calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_multi_container_recovers_when_one_runtime_was_deleted(
+        self, driver: FakeDriver, db_session: AsyncSession, cargo: Cargo
+    ):
+        """A partial runtime group must be cleaned up and recreated."""
+        mgr = SessionManager(driver, db_session)
+        profile = _multi_profile()
+
+        db_session.add(cargo)
+        await db_session.commit()
+
+        session = await mgr.create("sandbox-partial", cargo, profile)
+        session = await mgr.ensure_running(session, cargo, profile)
+
+        assert session.containers is not None
+        original_container_ids = [container["container_id"] for container in session.containers]
+        gull_container_id = next(
+            container["container_id"]
+            for container in session.containers
+            if container["name"] == "gull"
+        )
+        await driver.destroy(gull_container_id)
+
+        refreshed = await mgr.get(session.id)
+        assert refreshed is not None
+
+        recovered = await mgr.ensure_running(refreshed, cargo, profile)
+
+        assert recovered.observed_state == SessionStatus.RUNNING
+        assert recovered.containers is not None
+        recovered_container_ids = [container["container_id"] for container in recovered.containers]
+        assert recovered_container_ids != original_container_ids
+        assert all(
+            container_id not in driver._containers for container_id in original_container_ids
+        )
+        assert session.id in driver.remove_network_calls
+        assert len(driver.create_multi_calls) == 2
+        assert len(driver.start_multi_calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_partial_runtime_cleanup_failure_preserves_session_metadata(
+        self, driver: FakeDriver, db_session: AsyncSession, cargo: Cargo
+    ):
+        """A failed runtime cleanup must remain retryable with its metadata intact."""
+        mgr = SessionManager(driver, db_session)
+        profile = _multi_profile()
+
+        db_session.add(cargo)
+        await db_session.commit()
+
+        session = await mgr.create("sandbox-cleanup-failure", cargo, profile)
+        session = await mgr.ensure_running(session, cargo, profile)
+        assert session.containers is not None
+        original_container_id = session.container_id
+        original_endpoint = session.endpoint
+        original_containers = [dict(container) for container in session.containers]
+
+        gull_container_id = next(
+            container["container_id"]
+            for container in session.containers
+            if container["name"] == "gull"
+        )
+        await driver.destroy(gull_container_id)
+
+        with patch.object(
+            driver,
+            "destroy_runtime_instance",
+            AsyncMock(side_effect=RuntimeError("runtime cleanup failed")),
+        ):
+            with pytest.raises(SessionNotReadyError, match="cleanup"):
+                await mgr.ensure_running(session, cargo, profile)
+
+        await db_session.refresh(session)
+        assert session.observed_state == SessionStatus.RUNNING
+        assert session.container_id == original_container_id
+        assert session.endpoint == original_endpoint
+        assert session.containers == original_containers
+        assert len(driver.create_multi_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_partial_runtime_network_cleanup_failure_preserves_session_metadata(
+        self, driver: FakeDriver, db_session: AsyncSession, cargo: Cargo
+    ):
+        """A failed network cleanup must retain state for the next repair attempt."""
+        mgr = SessionManager(driver, db_session)
+        profile = _multi_profile()
+
+        db_session.add(cargo)
+        await db_session.commit()
+
+        session = await mgr.create("sandbox-network-cleanup-failure", cargo, profile)
+        session = await mgr.ensure_running(session, cargo, profile)
+        assert session.containers is not None
+        original_container_id = session.container_id
+        original_endpoint = session.endpoint
+        original_containers = [dict(container) for container in session.containers]
+
+        gull_container_id = next(
+            container["container_id"]
+            for container in session.containers
+            if container["name"] == "gull"
+        )
+        await driver.destroy(gull_container_id)
+
+        with patch.object(
+            driver,
+            "remove_session_network",
+            AsyncMock(side_effect=RuntimeError("network cleanup failed")),
+        ):
+            with pytest.raises(SessionNotReadyError, match="cleanup"):
+                await mgr.ensure_running(session, cargo, profile)
+
+        await db_session.refresh(session)
+        assert session.observed_state == SessionStatus.RUNNING
+        assert session.container_id == original_container_id
+        assert session.endpoint == original_endpoint
+        assert session.containers == original_containers
+        assert len(driver.create_multi_calls) == 1
 
     @pytest.mark.asyncio
     async def test_single_container_path_unchanged(

--- a/pkgs/bay/tests/unit/managers/test_session_multi.py
+++ b/pkgs/bay/tests/unit/managers/test_session_multi.py
@@ -18,7 +18,7 @@ from app.errors import SessionNotReadyError
 from app.managers.session.session import SessionManager
 from app.models.cargo import Cargo
 from app.models.session import Session, SessionStatus
-from tests.fakes import FakeDriver
+from tests.fakes import FakeContainerState, FakeDriver
 
 
 def _multi_profile() -> ProfileConfig:
@@ -167,6 +167,103 @@ class TestMultiContainerEnsureRunning:
         ship_container = next(c for c in session.containers if c["name"] == "ship")
         assert session.endpoint == ship_container["endpoint"]
         assert session.container_id == ship_container["container_id"]
+
+    @pytest.mark.asyncio
+    async def test_recovers_incomplete_starting_runtime_group(
+        self, driver: FakeDriver, db_session: AsyncSession, cargo: Cargo
+    ):
+        mgr = SessionManager(driver, db_session)
+        profile = _multi_profile()
+
+        db_session.add(cargo)
+        await db_session.commit()
+        session = await mgr.create("sandbox-starting-multi", cargo, profile)
+        session.observed_state = SessionStatus.STARTING
+        session.desired_state = SessionStatus.RUNNING
+        await db_session.commit()
+
+        await driver.create_session_network(session.id)
+        driver._containers["stale-ship"] = FakeContainerState(
+            container_id="stale-ship",
+            session_id=session.id,
+            profile_id=profile.id,
+            cargo_id=cargo.id,
+        )
+        driver._containers["stale-gull"] = FakeContainerState(
+            container_id="stale-gull",
+            session_id=session.id,
+            profile_id=profile.id,
+            cargo_id=cargo.id,
+        )
+
+        recovered = await mgr.ensure_running(session, cargo, profile)
+
+        assert recovered.observed_state == SessionStatus.RUNNING
+        assert recovered.containers is not None
+        assert len(recovered.containers) == 2
+        assert "stale-ship" not in driver._containers
+        assert "stale-gull" not in driver._containers
+        assert driver.remove_network_calls == [session.id]
+        assert driver.create_network_calls == [session.id, session.id]
+        assert len(driver.create_multi_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_keeps_multi_starting_state_when_runtime_discovery_fails(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        driver: FakeDriver,
+        db_session: AsyncSession,
+        cargo: Cargo,
+    ):
+        mgr = SessionManager(driver, db_session)
+        profile = _multi_profile()
+
+        db_session.add(cargo)
+        await db_session.commit()
+        session = await mgr.create("sandbox-starting-multi-probe-error", cargo, profile)
+        session.observed_state = SessionStatus.STARTING
+        session.desired_state = SessionStatus.RUNNING
+        await db_session.commit()
+
+        async def _raise_runtime_discovery_error(*, labels):
+            raise RuntimeError("runtime backend unavailable")
+
+        monkeypatch.setattr(driver, "list_runtime_instances", _raise_runtime_discovery_error)
+
+        with pytest.raises(SessionNotReadyError, match="Session is starting"):
+            await mgr.ensure_running(session, cargo, profile)
+
+        await db_session.refresh(session)
+        assert session.observed_state == SessionStatus.STARTING
+        assert session.container_id is None
+        assert not hasattr(driver, "create_multi_calls")
+
+    @pytest.mark.asyncio
+    async def test_finishes_starting_session_when_complete_runtime_group_is_running(
+        self, driver: FakeDriver, db_session: AsyncSession, cargo: Cargo
+    ):
+        mgr = SessionManager(driver, db_session)
+        profile = _multi_profile()
+
+        db_session.add(cargo)
+        await db_session.commit()
+        session = await mgr.create("sandbox-starting-multi-running", cargo, profile)
+        session = await mgr.ensure_running(session, cargo, profile)
+
+        original_container_id = session.container_id
+        original_endpoint = session.endpoint
+        original_containers = [dict(container) for container in session.containers or []]
+        session.observed_state = SessionStatus.STARTING
+        await db_session.commit()
+
+        recovered = await mgr.ensure_running(session, cargo, profile)
+
+        assert recovered.observed_state == SessionStatus.RUNNING
+        assert recovered.container_id == original_container_id
+        assert recovered.endpoint == original_endpoint
+        assert recovered.containers == original_containers
+        assert len(driver.create_multi_calls) == 1
+        assert len(driver.start_multi_calls) == 1
 
     @pytest.mark.asyncio
     async def test_multi_container_idempotent(

--- a/pkgs/bay/tests/unit/test_runtime_health.py
+++ b/pkgs/bay/tests/unit/test_runtime_health.py
@@ -1,0 +1,63 @@
+from app.drivers.base import ContainerStatus, RuntimeInstance
+from app.utils.runtime_health import all_expected_runtimes_running
+
+
+def _runtime(runtime_id: str, state: ContainerStatus) -> RuntimeInstance:
+    return RuntimeInstance(
+        id=runtime_id,
+        name=runtime_id,
+        labels={},
+        state=state.value,
+    )
+
+
+def test_all_expected_runtimes_running_requires_each_docker_container():
+    expected = [
+        {"name": "ship", "container_id": "ship-id"},
+        {"name": "browser", "container_id": "browser-id"},
+    ]
+
+    assert not all_expected_runtimes_running(
+        expected,
+        [_runtime("ship-id", ContainerStatus.RUNNING)],
+    )
+
+
+def test_all_expected_runtimes_running_accepts_shared_kubernetes_pod():
+    expected = [
+        {"name": "ship", "container_id": "pod-id"},
+        {"name": "browser", "container_id": "pod-id"},
+    ]
+
+    assert all_expected_runtimes_running(
+        expected,
+        [_runtime("pod-id", ContainerStatus.RUNNING)],
+    )
+
+
+def test_all_expected_runtimes_running_rejects_stopped_runtime():
+    expected = [{"name": "ship", "container_id": "ship-id"}]
+
+    assert not all_expected_runtimes_running(
+        expected,
+        [_runtime("ship-id", ContainerStatus.EXITED)],
+    )
+
+
+def test_all_expected_runtimes_running_rejects_missing_persisted_ids():
+    assert not all_expected_runtimes_running(
+        [{"name": "ship", "container_id": None}],
+        [_runtime("ship-id", ContainerStatus.RUNNING)],
+    )
+
+
+def test_all_expected_runtimes_running_rejects_partially_missing_persisted_ids():
+    expected = [
+        {"name": "ship", "container_id": "ship-id"},
+        {"name": "browser", "container_id": None},
+    ]
+
+    assert not all_expected_runtimes_running(
+        expected,
+        [_runtime("ship-id", ContainerStatus.RUNNING)],
+    )

--- a/pkgs/bay/tests/unit/warm_pool/test_warm_pool_manager.py
+++ b/pkgs/bay/tests/unit/warm_pool/test_warm_pool_manager.py
@@ -289,6 +289,53 @@ class TestWarmPoolSchedulerReconcile:
     """Tests for periodic runtime/database reconciliation in warm pool."""
 
     @pytest.mark.asyncio
+    async def test_reconcile_requeues_pending_sandbox_after_warmup_failure(
+        self,
+        db_session,
+        driver,
+        monkeypatch,
+    ):
+        sandbox_mgr = SandboxManager(driver=driver, db_session=db_session)
+        sandbox = await sandbox_mgr.create_warm_sandbox(profile_id="python-default")
+
+        session = Session(
+            id="sess-warm-failed",
+            sandbox_id=sandbox.id,
+            profile_id="python-default",
+            container_id=None,
+            endpoint=None,
+            observed_state=SessionStatus.FAILED,
+            desired_state=SessionStatus.RUNNING,
+        )
+        db_session.add(session)
+        sandbox.current_session_id = session.id
+        await db_session.commit()
+
+        queue = _FakeWarmupQueue()
+        scheduler = WarmPoolScheduler(
+            config=SimpleNamespace(interval_seconds=60, run_on_startup=False),
+            warmup_queue=queue,
+        )
+
+        class _SessionFactory:
+            async def __aenter__(self):
+                return db_session
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        monkeypatch.setattr(
+            "app.db.session.get_async_session",
+            lambda: _SessionFactory(),
+        )
+        monkeypatch.setattr("app.api.dependencies.get_driver", lambda: driver)
+
+        reconciled = await scheduler._reconcile_profile_runtime_state("python-default")
+
+        assert reconciled == 1
+        assert queue.enqueued == [(sandbox.id, sandbox.owner)]
+
+    @pytest.mark.asyncio
     async def test_reconcile_requeues_available_sandbox_when_runtime_missing(
         self,
         db_session,
@@ -353,8 +400,75 @@ class TestWarmPoolSchedulerReconcile:
         session_result = await db_session.execute(select(Session).where(Session.id == session.id))
         updated_session = session_result.scalars().first()
         assert updated_session is not None
-        assert updated_session.observed_state == SessionStatus.STOPPED
-        assert updated_session.endpoint is None
+        assert updated_session.observed_state == SessionStatus.RUNNING
+        assert updated_session.endpoint == "http://dead-runtime"
+
+    @pytest.mark.asyncio
+    async def test_reconcile_does_not_reset_sandbox_claimed_during_runtime_probe(
+        self,
+        db_session,
+        driver,
+        monkeypatch,
+    ):
+        sandbox_mgr = SandboxManager(driver=driver, db_session=db_session)
+        sandbox = await sandbox_mgr.create_warm_sandbox(profile_id="python-default")
+        await sandbox_mgr.mark_warm_available(sandbox.id)
+
+        session = Session(
+            id="sess-warm-claimed-during-probe",
+            sandbox_id=sandbox.id,
+            profile_id="python-default",
+            container_id="missing-container",
+            endpoint="http://dead-runtime",
+            observed_state=SessionStatus.RUNNING,
+            desired_state=SessionStatus.RUNNING,
+        )
+        db_session.add(session)
+        sandbox.current_session_id = session.id
+        await db_session.commit()
+
+        queue = _FakeWarmupQueue()
+        scheduler = WarmPoolScheduler(
+            config=SimpleNamespace(interval_seconds=60, run_on_startup=False),
+            warmup_queue=queue,
+        )
+        driver.set_status_override(
+            "missing-container",
+            ContainerInfo(
+                container_id="missing-container",
+                status=ContainerStatus.NOT_FOUND,
+            ),
+        )
+
+        class _SessionFactory:
+            enters = 0
+
+            async def __aenter__(self):
+                type(self).enters += 1
+                if type(self).enters == 2:
+                    sandbox.is_warm_pool = False
+                    sandbox.warm_state = WarmState.CLAIMED.value
+                    sandbox.owner = "claimed-owner"
+                    await db_session.commit()
+                return db_session
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        monkeypatch.setattr(
+            "app.db.session.get_async_session",
+            lambda: _SessionFactory(),
+        )
+        monkeypatch.setattr("app.api.dependencies.get_driver", lambda: driver)
+
+        reconciled = await scheduler._reconcile_profile_runtime_state("python-default")
+
+        assert reconciled == 0
+        assert queue.enqueued == []
+        await db_session.refresh(sandbox)
+        assert sandbox.is_warm_pool is False
+        assert sandbox.warm_state == WarmState.CLAIMED.value
+        assert sandbox.owner == "claimed-owner"
 
     @pytest.mark.asyncio
     async def test_reconcile_keeps_available_sandbox_when_multi_runtime_alive(
@@ -408,11 +522,17 @@ class TestWarmPoolSchedulerReconcile:
             assert labels == {"bay.session_id": session.id}
             return [
                 RuntimeInstance(
-                    id="runtime-1",
-                    name="bay-session-sess-warm-multi",
+                    id="primary-container",
+                    name="bay-sess-warm-multi-ship",
                     labels={"bay.session_id": session.id},
                     state=ContainerStatus.RUNNING.value,
-                )
+                ),
+                RuntimeInstance(
+                    id="browser-container",
+                    name="bay-sess-warm-multi-browser",
+                    labels={"bay.session_id": session.id},
+                    state=ContainerStatus.RUNNING.value,
+                ),
             ]
 
         driver.list_runtime_instances = _list_runtime_instances
@@ -438,6 +558,90 @@ class TestWarmPoolSchedulerReconcile:
         updated_sandbox = sandbox_result.scalars().first()
         assert updated_sandbox is not None
         assert updated_sandbox.warm_state == WarmState.AVAILABLE.value
+
+    @pytest.mark.asyncio
+    async def test_reconcile_requeues_available_sandbox_when_multi_runtime_is_partial(
+        self,
+        db_session,
+        driver,
+        monkeypatch,
+    ):
+        sandbox_mgr = SandboxManager(driver=driver, db_session=db_session)
+        sandbox = await sandbox_mgr.create_warm_sandbox(profile_id="python-default")
+        await sandbox_mgr.mark_warm_available(sandbox.id)
+
+        session = Session(
+            id="sess-warm-multi-partial",
+            sandbox_id=sandbox.id,
+            profile_id="python-default",
+            container_id="primary-container",
+            endpoint="http://alive-runtime",
+            observed_state=SessionStatus.RUNNING,
+            desired_state=SessionStatus.RUNNING,
+            containers=[
+                {
+                    "name": "ship",
+                    "container_id": "primary-container",
+                    "endpoint": "http://alive-runtime",
+                    "status": "running",
+                    "runtime_type": "ship",
+                    "capabilities": ["python"],
+                },
+                {
+                    "name": "browser",
+                    "container_id": "browser-container",
+                    "endpoint": "http://browser-runtime",
+                    "status": "running",
+                    "runtime_type": "browser",
+                    "capabilities": ["browser"],
+                },
+            ],
+        )
+        db_session.add(session)
+        sandbox.current_session_id = session.id
+        await db_session.commit()
+
+        queue = _FakeWarmupQueue()
+        scheduler = WarmPoolScheduler(
+            config=SimpleNamespace(interval_seconds=60, run_on_startup=False),
+            warmup_queue=queue,
+        )
+
+        async def _list_runtime_instances(*, labels):
+            assert labels == {"bay.session_id": session.id}
+            return [
+                RuntimeInstance(
+                    id="primary-container",
+                    name="bay-sess-warm-multi-partial-ship",
+                    labels={"bay.session_id": session.id},
+                    state=ContainerStatus.RUNNING.value,
+                )
+            ]
+
+        driver.list_runtime_instances = _list_runtime_instances
+
+        class _SessionFactory:
+            async def __aenter__(self):
+                return db_session
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        monkeypatch.setattr(
+            "app.db.session.get_async_session",
+            lambda: _SessionFactory(),
+        )
+        monkeypatch.setattr("app.api.dependencies.get_driver", lambda: driver)
+
+        reconciled = await scheduler._reconcile_profile_runtime_state("python-default")
+
+        assert reconciled == 1
+        assert queue.enqueued == [(sandbox.id, sandbox.owner)]
+
+        sandbox_result = await db_session.execute(select(Sandbox).where(Sandbox.id == sandbox.id))
+        updated_sandbox = sandbox_result.scalars().first()
+        assert updated_sandbox is not None
+        assert updated_sandbox.warm_state is None
 
     @pytest.mark.asyncio
     async def test_reconcile_keeps_available_sandbox_when_single_runtime_alive(

--- a/pkgs/bay/tests/unit/warm_pool/test_warm_pool_manager.py
+++ b/pkgs/bay/tests/unit/warm_pool/test_warm_pool_manager.py
@@ -336,6 +336,59 @@ class TestWarmPoolSchedulerReconcile:
         assert queue.enqueued == [(sandbox.id, sandbox.owner)]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "observed_state",
+        [SessionStatus.STARTING, SessionStatus.RUNNING],
+    )
+    async def test_reconcile_does_not_requeue_pending_sandbox_with_active_session(
+        self,
+        observed_state,
+        db_session,
+        driver,
+        monkeypatch,
+    ):
+        sandbox_mgr = SandboxManager(driver=driver, db_session=db_session)
+        sandbox = await sandbox_mgr.create_warm_sandbox(profile_id="python-default")
+
+        session = Session(
+            id=f"sess-warm-{observed_state.value}",
+            sandbox_id=sandbox.id,
+            profile_id="python-default",
+            container_id="warmup-container",
+            endpoint="http://warmup-runtime"
+            if observed_state == SessionStatus.RUNNING
+            else None,
+            observed_state=observed_state,
+            desired_state=SessionStatus.RUNNING,
+        )
+        db_session.add(session)
+        sandbox.current_session_id = session.id
+        await db_session.commit()
+
+        queue = _FakeWarmupQueue()
+        scheduler = WarmPoolScheduler(
+            config=SimpleNamespace(interval_seconds=60, run_on_startup=False),
+            warmup_queue=queue,
+        )
+
+        class _SessionFactory:
+            async def __aenter__(self):
+                return db_session
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        monkeypatch.setattr(
+            "app.db.session.get_async_session",
+            lambda: _SessionFactory(),
+        )
+
+        reconciled = await scheduler._reconcile_profile_runtime_state("python-default")
+
+        assert reconciled == 0
+        assert queue.enqueued == []
+
+    @pytest.mark.asyncio
     async def test_reconcile_requeues_available_sandbox_when_runtime_missing(
         self,
         db_session,

--- a/pkgs/bay/tests/unit/warm_pool/test_warm_pool_manager.py
+++ b/pkgs/bay/tests/unit/warm_pool/test_warm_pool_manager.py
@@ -95,7 +95,7 @@ class TestMarkWarmAvailable:
 
         fixed_now = utcnow()
         with patch("app.managers.sandbox.sandbox.utcnow", return_value=fixed_now):
-            await sandbox_mgr.mark_warm_available(sandbox.id, warm_rotate_ttl=1800)
+            marked = await sandbox_mgr.mark_warm_available(sandbox.id, warm_rotate_ttl=1800)
 
         # Refetch
         result = await db_session.execute(select(Sandbox).where(Sandbox.id == sandbox.id))
@@ -104,6 +104,26 @@ class TestMarkWarmAvailable:
         assert updated.warm_state == WarmState.AVAILABLE.value
         assert updated.warm_ready_at == fixed_now
         assert updated.warm_rotate_at == fixed_now + timedelta(seconds=1800)
+        assert marked is True
+
+    @pytest.mark.asyncio
+    async def test_mark_available_does_not_revive_retiring_sandbox(
+        self,
+        sandbox_mgr,
+        db_session,
+    ):
+        sandbox = await sandbox_mgr.create_warm_sandbox(profile_id="python-default")
+        await sandbox_mgr.mark_warm_available(sandbox.id)
+        await sandbox_mgr.mark_warm_retiring(sandbox.id)
+
+        marked = await sandbox_mgr.mark_warm_available(sandbox.id)
+
+        sandbox_id = sandbox.id
+        db_session.expire_all()
+        result = await db_session.execute(select(Sandbox).where(Sandbox.id == sandbox_id))
+        updated = result.scalars().one()
+        assert marked is False
+        assert updated.warm_state == WarmState.RETIRING.value
 
 
 class TestClaimWarmSandbox:

--- a/pkgs/bay/tests/unit/warm_pool/test_warmup_queue.py
+++ b/pkgs/bay/tests/unit/warm_pool/test_warmup_queue.py
@@ -5,14 +5,15 @@ from __future__ import annotations
 from unittest.mock import AsyncMock
 
 import pytest
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
-from sqlmodel import SQLModel
+from sqlmodel import SQLModel, select
 
 from app.config import WarmPoolConfig
 from app.managers.sandbox import SandboxManager
 from app.models.cargo import Cargo
-from app.models.sandbox import Sandbox
+from app.models.sandbox import Sandbox, WarmState
 from app.models.session import Session, SessionStatus
 from app.services.warm_pool.queue import WarmupQueue
 from tests.fakes import FakeDriver
@@ -250,3 +251,85 @@ class TestWarmupQueueRecovery:
 
         ensure_running_mock.assert_awaited_once()
         assert queue.stats.success_total == 1
+
+    @pytest.mark.asyncio
+    async def test_process_task_marks_available_after_reconcile_resets_stale_state(
+        self,
+        db_session: AsyncSession,
+        driver: FakeDriver,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        config = _make_config()
+        queue = WarmupQueue(config=config)
+
+        cargo = Cargo(
+            id="cargo-recovery-race",
+            owner="warm-pool",
+            managed=True,
+            driver_ref="vol-cargo-recovery-race",
+        )
+        sandbox = Sandbox(
+            id="sandbox-recovery-race",
+            owner="warm-pool",
+            profile_id="python-default",
+            cargo_id=cargo.id,
+            is_warm_pool=True,
+            warm_state=WarmState.AVAILABLE.value,
+        )
+        session = Session(
+            id="sess-recovery-race",
+            sandbox_id=sandbox.id,
+            profile_id="python-default",
+            container_id="replacement-container",
+            endpoint="http://replacement-runtime",
+            observed_state=SessionStatus.RUNNING,
+            desired_state=SessionStatus.RUNNING,
+        )
+        sandbox.current_session_id = session.id
+
+        db_session.add(cargo)
+        db_session.add(sandbox)
+        db_session.add(session)
+        await db_session.commit()
+
+        class _SessionFactory:
+            async def __aenter__(self):
+                return db_session
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        monkeypatch.setattr(
+            "app.db.session.get_async_session",
+            lambda: _SessionFactory(),
+        )
+        monkeypatch.setattr("app.api.dependencies.get_driver", lambda: driver)
+
+        async def _ensure_running(_manager, loaded_sandbox):
+            assert loaded_sandbox.warm_state == WarmState.AVAILABLE.value
+            await db_session.execute(
+                update(Sandbox)
+                .where(Sandbox.id == loaded_sandbox.id)
+                .values(
+                    warm_state=None,
+                    warm_ready_at=None,
+                    warm_rotate_at=None,
+                )
+                .execution_options(synchronize_session=False)
+            )
+            await db_session.commit()
+            assert loaded_sandbox.warm_state == WarmState.AVAILABLE.value
+            return session
+
+        monkeypatch.setattr(SandboxManager, "ensure_running", _ensure_running)
+
+        await queue._process_task(
+            task=type("Task", (), {"sandbox_id": sandbox.id, "owner": sandbox.owner})(),
+            worker_id=0,
+        )
+
+        sandbox_id = sandbox.id
+        db_session.expire_all()
+        result = await db_session.execute(select(Sandbox).where(Sandbox.id == sandbox_id))
+        updated_sandbox = result.scalars().one()
+        assert updated_sandbox.warm_state == WarmState.AVAILABLE.value


### PR DESCRIPTION
## 修改内容

- 周期检查待处理和可用的预热沙盒，运行时缺失或多容器组不完整时重新加入预热队列。
- 预热任务始终检查真实运行时状态，并恢复中断的会话启动。
- 清理失败时保留会话元数据，供后续任务再次处理。
- Kubernetes Pod 删除完成后再创建同名运行时。
- 预热恢复完成后，通过 `warm_state IS NULL` 条件更新写回 `available`，避免并发调度留下永久待处理状态，同时保留已领取和已退役状态。

## 问题原因

预热队列只保存在进程内，任务失败或进程重启后可能长期停留在待处理状态。运行时探测曾把部分存在的多容器组视为健康，清理失败后又会丢失再次处理所需的信息。调度器重置状态与预热任务同时执行时，任务还可能读取旧的 ORM 对象并跳过可用状态写回。

## 验证

- 预热池单元测试：`38 passed`
- 生产组合分支单元测试：`525 passed`
- Ruff：通过
- v0.4.0 实际运行验证：失效运行时恢复后为 `available=1`、`pending=0`
- 双沙盒验证：冷启动首个 Shell 42.752 秒，百度页面标题正确，截图 28,866 字节，测试沙盒均已清理
