### PR TITLE
fix(bay): 清理终止运行时引用的孤立 Cargo

### DIFF
--- a/pkgs/bay/app/services/gc/tasks/orphan_cargo.py
+++ b/pkgs/bay/app/services/gc/tasks/orphan_cargo.py
@@ -93,19 +93,39 @@ class OrphanCargoGC(GCTask):
         """Check whether any active runtime instance still references the cargo.
 
         Stopped containers and completed pods retain labels until they are removed, but no
-        longer use the cargo. Unknown or transitional states remain conservative and keep
-        the cargo until a later GC cycle.
+        longer use the cargo. Remove those terminal runtime objects, then query again before
+        allowing cargo deletion. Unknown or transitional states remain conservative.
         """
-        instances = await self._driver.list_runtime_instances(
+        labels = {
+            "bay.cargo_id": cargo_id,
+            "bay.managed": "true",
+        }
+        instances = await self._driver.list_runtime_instances(labels=labels)
+        if any(
+            instance.state.lower() not in _TERMINAL_RUNTIME_STATES
+            for instance in instances
+        ):
+            return True
+
+        for instance in instances:
+            self._log.info(
+                "gc.orphan_cargo.remove_terminal_runtime",
+                cargo_id=cargo_id,
+                runtime_id=instance.id,
+                runtime_state=instance.state,
+            )
+            await self._driver.destroy_runtime_instance(instance.id)
+
+        if not instances:
+            return False
+
+        remaining = await self._driver.list_runtime_instances(
             labels={
                 "bay.cargo_id": cargo_id,
                 "bay.managed": "true",
             }
         )
-        return any(
-            instance.state.lower() not in _TERMINAL_RUNTIME_STATES
-            for instance in instances
-        )
+        return bool(remaining)
 
     async def _find_orphans(self) -> list[str]:
         """Find orphan managed cargo IDs."""

--- a/pkgs/bay/app/services/gc/tasks/orphan_cargo.py
+++ b/pkgs/bay/app/services/gc/tasks/orphan_cargo.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger()
 
+_TERMINAL_RUNTIME_STATES = frozenset({"dead", "exited", "failed", "succeeded"})
+
 
 class OrphanCargoGC(GCTask):
     """GC task for cleaning up orphan managed cargos.
@@ -88,10 +90,11 @@ class OrphanCargoGC(GCTask):
         return result
 
     async def _has_runtime_references(self, cargo_id: str) -> bool:
-        """Check whether any runtime instance still references the cargo.
+        """Check whether any active runtime instance still references the cargo.
 
-        Conservative by design: if any runtime instance still carries the cargo label,
-        skip deletion for this GC cycle and let a later cycle retry after runtime cleanup.
+        Stopped containers and completed pods retain labels until they are removed, but no
+        longer use the cargo. Unknown or transitional states remain conservative and keep
+        the cargo until a later GC cycle.
         """
         instances = await self._driver.list_runtime_instances(
             labels={
@@ -99,7 +102,10 @@ class OrphanCargoGC(GCTask):
                 "bay.managed": "true",
             }
         )
-        return len(instances) > 0
+        return any(
+            instance.state.lower() not in _TERMINAL_RUNTIME_STATES
+            for instance in instances
+        )
 
     async def _find_orphans(self) -> list[str]:
         """Find orphan managed cargo IDs."""

--- a/pkgs/bay/tests/unit/gc/test_gc_tasks.py
+++ b/pkgs/bay/tests/unit/gc/test_gc_tasks.py
@@ -475,19 +475,19 @@ class TestOrphanCargoGC:
         from tests.fakes import FakeDriver
 
         driver = FakeDriver()
-        driver.list_runtime_instances = AsyncMock(
-            return_value=[
-                RuntimeInstance(
-                    id="container-exited",
-                    name="bay-session-sess-old",
-                    labels={
-                        "bay.cargo_id": "ws-orphan-1",
-                        "bay.managed": "true",
-                    },
-                    state="exited",
-                )
-            ]
+        exited_instance = RuntimeInstance(
+            id="container-exited",
+            name="bay-session-sess-old",
+            labels={
+                "bay.cargo_id": "ws-orphan-1",
+                "bay.managed": "true",
+            },
+            state="exited",
         )
+        driver.list_runtime_instances = AsyncMock(
+            side_effect=[[exited_instance], []]
+        )
+        driver.destroy_runtime_instance = AsyncMock()
         db_session = AsyncMock()
 
         task = OrphanCargoGC(driver, db_session)
@@ -499,7 +499,46 @@ class TestOrphanCargoGC:
 
         assert result.cleaned_count == 1
         assert result.skipped_count == 0
+        driver.destroy_runtime_instance.assert_awaited_once_with("container-exited")
         task._cargo_mgr.delete_internal_by_id.assert_awaited_once_with("ws-orphan-1")
+
+    @pytest.mark.asyncio
+    async def test_orphan_cargo_rechecks_references_after_terminal_cleanup(self):
+        """A new active reference discovered after cleanup must preserve cargo."""
+        from app.services.gc.tasks.orphan_cargo import OrphanCargoGC
+        from tests.fakes import FakeDriver
+
+        labels = {"bay.cargo_id": "ws-orphan-1", "bay.managed": "true"}
+        exited_instance = RuntimeInstance(
+            id="container-exited",
+            name="bay-session-sess-old",
+            labels=labels,
+            state="exited",
+        )
+        running_instance = RuntimeInstance(
+            id="container-running",
+            name="bay-session-sess-new",
+            labels=labels,
+            state="running",
+        )
+        driver = FakeDriver()
+        driver.list_runtime_instances = AsyncMock(
+            side_effect=[[exited_instance], [running_instance]]
+        )
+        driver.destroy_runtime_instance = AsyncMock()
+        db_session = AsyncMock()
+
+        task = OrphanCargoGC(driver, db_session)
+        task._find_orphans = AsyncMock(return_value=["ws-orphan-1"])
+        task._cargo_mgr = MagicMock()
+        task._cargo_mgr.delete_internal_by_id = AsyncMock()
+
+        result = await task.run()
+
+        assert result.cleaned_count == 0
+        assert result.skipped_count == 1
+        driver.destroy_runtime_instance.assert_awaited_once_with("container-exited")
+        task._cargo_mgr.delete_internal_by_id.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_orphan_cargo_no_orphans(self):

--- a/pkgs/bay/tests/unit/gc/test_gc_tasks.py
+++ b/pkgs/bay/tests/unit/gc/test_gc_tasks.py
@@ -467,6 +467,41 @@ class TestOrphanCargoGC:
         task._cargo_mgr.delete_internal_by_id.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_orphan_cargo_deletes_when_only_exited_runtime_references_volume(
+        self,
+    ):
+        """Exited runtimes must not keep orphan cargo alive indefinitely."""
+        from app.services.gc.tasks.orphan_cargo import OrphanCargoGC
+        from tests.fakes import FakeDriver
+
+        driver = FakeDriver()
+        driver.list_runtime_instances = AsyncMock(
+            return_value=[
+                RuntimeInstance(
+                    id="container-exited",
+                    name="bay-session-sess-old",
+                    labels={
+                        "bay.cargo_id": "ws-orphan-1",
+                        "bay.managed": "true",
+                    },
+                    state="exited",
+                )
+            ]
+        )
+        db_session = AsyncMock()
+
+        task = OrphanCargoGC(driver, db_session)
+        task._find_orphans = AsyncMock(return_value=["ws-orphan-1"])
+        task._cargo_mgr = MagicMock()
+        task._cargo_mgr.delete_internal_by_id = AsyncMock()
+
+        result = await task.run()
+
+        assert result.cleaned_count == 1
+        assert result.skipped_count == 0
+        task._cargo_mgr.delete_internal_by_id.assert_awaited_once_with("ws-orphan-1")
+
+    @pytest.mark.asyncio
     async def test_orphan_cargo_no_orphans(self):
         """Should handle case when no orphan cargos are found."""
         from tests.fakes import FakeDriver


### PR DESCRIPTION
## 修改内容

- 孤立 Cargo 清理时区分运行中实例与已经终止的实例。
- 清除 `dead`、`exited`、`failed` 和 `succeeded` 状态的旧实例后，再次查询运行时引用。
- 仍存在活动或状态未知的实例时保留 Cargo。
- 删除前再次查询，处理扫描与删除之间新增运行时的并发情况。

## 问题原因

Docker 运行时查询包含已经退出的容器。旧实现只要看到任意引用就会永久跳过 Cargo 清理，导致已删除沙盒的目录和退出容器持续残留。

## 验证

- 专项单元测试：`24 passed`
- 生产组合分支单元测试：`525 passed`
- Ruff：通过
- 实际启动清理：移除 4 个退出运行时并清理 2 个孤立 Cargo，错误数为 0

## Summary by Sourcery

Refine orphan Cargo garbage collection to ignore terminal runtime instances while still protecting cargos referenced by active or newly created runtimes.

Bug Fixes:
- Ensure orphan cargos referenced only by exited or otherwise terminal runtimes are cleaned up instead of being preserved indefinitely.

Enhancements:
- Clean up terminal runtime instances before deciding on orphan cargo deletion and re-check for active references to handle races between scanning and deletion.

Tests:
- Add unit tests covering cleanup when only exited runtimes reference a cargo and when a new active runtime appears after terminal runtime cleanup.