### PR TITLE
fix(bay): 改善 SQLite 并发访问

### DIFF
--- a/pkgs/bay/app/db/session.py
+++ b/pkgs/bay/app/db/session.py
@@ -32,7 +32,7 @@ def _configure_sqlite_connection(dbapi_connection, _connection_record) -> None:
     try:
         cursor.execute(f"PRAGMA busy_timeout={_SQLITE_BUSY_TIMEOUT_MS}")
         cursor.execute("PRAGMA journal_mode=WAL")
-        cursor.execute("PRAGMA synchronous=NORMAL")
+        cursor.execute("PRAGMA synchronous=FULL")
     finally:
         cursor.close()
 

--- a/pkgs/bay/app/db/session.py
+++ b/pkgs/bay/app/db/session.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import structlog
-from sqlalchemy import inspect, text
+from sqlalchemy import event, inspect, text
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
@@ -22,17 +22,42 @@ logger = structlog.get_logger()
 _engine = None
 _async_session_factory = None
 
+_SQLITE_BUSY_TIMEOUT_SECONDS = 30
+_SQLITE_BUSY_TIMEOUT_MS = _SQLITE_BUSY_TIMEOUT_SECONDS * 1000
+
+
+def _configure_sqlite_connection(dbapi_connection, _connection_record) -> None:
+    """Configure persistent SQLite connections for concurrent Bay tasks."""
+    cursor = dbapi_connection.cursor()
+    try:
+        cursor.execute(f"PRAGMA busy_timeout={_SQLITE_BUSY_TIMEOUT_MS}")
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA synchronous=NORMAL")
+    finally:
+        cursor.close()
+
 
 def _get_engine():
     """Get or create the async engine."""
     global _engine
     if _engine is None:
         settings = get_settings()
+        is_sqlite = settings.database.url.startswith("sqlite")
+        connect_args = (
+            {"timeout": _SQLITE_BUSY_TIMEOUT_SECONDS} if is_sqlite else {}
+        )
         _engine = create_async_engine(
             settings.database.url,
             echo=settings.database.echo,
             future=True,
+            connect_args=connect_args,
         )
+        if is_sqlite:
+            event.listen(
+                _engine.sync_engine,
+                "connect",
+                _configure_sqlite_connection,
+            )
     return _engine
 
 

--- a/pkgs/bay/tests/unit/db/test_sqlite_connection.py
+++ b/pkgs/bay/tests/unit/db/test_sqlite_connection.py
@@ -1,0 +1,36 @@
+"""SQLite connection settings used by Bay's persistent database."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+
+from app.config import DatabaseConfig, Settings
+from app.db import session as db_session
+
+
+@pytest.mark.asyncio
+async def test_file_sqlite_uses_wal_and_busy_timeout(tmp_path, monkeypatch):
+    database_path = tmp_path / "bay.db"
+    settings = Settings(
+        database=DatabaseConfig(
+            url=f"sqlite+aiosqlite:///{database_path.as_posix()}",
+            echo=False,
+        )
+    )
+
+    await db_session.close_db()
+    monkeypatch.setattr(db_session, "get_settings", lambda: settings)
+
+    engine = db_session._get_engine()
+    try:
+        async with engine.connect() as connection:
+            journal_mode = await connection.scalar(text("PRAGMA journal_mode"))
+            synchronous = await connection.scalar(text("PRAGMA synchronous"))
+            busy_timeout = await connection.scalar(text("PRAGMA busy_timeout"))
+
+        assert journal_mode == "wal"
+        assert synchronous == 1
+        assert busy_timeout == 30_000
+    finally:
+        await db_session.close_db()

--- a/pkgs/bay/tests/unit/db/test_sqlite_connection.py
+++ b/pkgs/bay/tests/unit/db/test_sqlite_connection.py
@@ -30,7 +30,7 @@ async def test_file_sqlite_uses_wal_and_busy_timeout(tmp_path, monkeypatch):
             busy_timeout = await connection.scalar(text("PRAGMA busy_timeout"))
 
         assert journal_mode == "wal"
-        assert synchronous == 1
+        assert synchronous == 2
         assert busy_timeout == 30_000
     finally:
         await db_session.close_db()


### PR DESCRIPTION
## 修改内容

- SQLite 连接超时设置为 30 秒。
- 每个 SQLite 连接设置 `busy_timeout=30000`、`journal_mode=WAL` 和 `synchronous=FULL`。
- 其他数据库驱动保持原有连接参数。

## 问题原因

Bay 的调度器、垃圾回收任务和 API 请求会并发访问同一个 SQLite 文件。默认回滚日志与较短等待时间容易在写事务重叠时返回 `database is locked`。

## 验证

- 专项单元测试：`1 passed`
- 生产组合分支单元测试：`525 passed`
- Ruff：通过
- 实际运行参数：`journal_mode=wal`、`synchronous=2`、`busy_timeout=30000`

## Summary by Sourcery

Improve SQLite configuration for concurrent Bay tasks while keeping other database backends unchanged.

Bug Fixes:
- Reduce SQLite `database is locked` errors by increasing connection timeout and configuring write-ahead logging with appropriate sync settings.

Enhancements:
- Introduce centralized SQLite connection configuration applied on engine connect events.
- Derive SQLite-specific async engine `connect_args` from settings while leaving non-SQLite drivers with existing parameters.

Tests:
- Add an async unit test verifying SQLite connections use WAL journal mode, FULL synchronous setting, and a 30-second busy timeout.