### PR TITLE
fix(bay): 修复 Docker bind Cargo 目录处理

### DIFF
--- a/pkgs/bay/app/drivers/docker/docker.py
+++ b/pkgs/bay/app/drivers/docker/docker.py
@@ -88,6 +88,8 @@ class DockerDriver(Driver):
 
         self._log = logger.bind(driver="docker")
         self._client: aiodocker.Docker | None = None
+        self._cargo_root_path = Path(settings.cargo.root_path)
+        self._configured_host_root = settings.cargo.host_root_path
         # Cached host-side cargo root path, resolved once on first use.
         self._resolved_host_root: str | None | _UNSET = _UNSET
 
@@ -109,15 +111,13 @@ class DockerDriver(Driver):
         if self._resolved_host_root is not _UNSET:
             return self._resolved_host_root  # type: ignore[return-value]
 
-        settings = get_settings()
-
         # 1. Explicit config always wins.
-        if settings.cargo.host_root_path:
-            self._resolved_host_root = settings.cargo.host_root_path
+        if self._configured_host_root:
+            self._resolved_host_root = self._configured_host_root
             return self._resolved_host_root
 
         # 2. Auto-detect via /proc/self/mountinfo.
-        root_path = settings.cargo.root_path.rstrip("/")
+        root_path = str(self._cargo_root_path).rstrip("/") or "/"
         try:
             with open("/proc/self/mountinfo") as f:
                 for line in f:
@@ -512,6 +512,10 @@ class DockerDriver(Driver):
 
     # Volume management
 
+    def _local_cargo_path(self, volume_ref: str) -> Path:
+        """Map a host bind path or volume name to Bay's mounted cargo root."""
+        return self._cargo_root_path / Path(volume_ref).name
+
     async def create_volume(self, name: str, labels: dict[str, str] | None = None) -> str:
         """Create a cargo volume.
 
@@ -527,11 +531,18 @@ class DockerDriver(Driver):
         host_root = await self._resolve_host_root()
 
         if host_root:
-            # Bind-mount mode: directory on the Docker host
-            cargo_path = Path(host_root) / name
-            cargo_path.mkdir(parents=True, exist_ok=True)
-            self._log.info("docker.create_volume.bind", name=name, path=str(cargo_path))
-            return str(cargo_path)
+            # Create through Bay's mounted path, then return the equivalent
+            # Docker-host path for use in the daemon's Binds configuration.
+            local_path = self._local_cargo_path(name)
+            local_path.mkdir(parents=True, exist_ok=True)
+            host_path = Path(host_root) / Path(name).name
+            self._log.info(
+                "docker.create_volume.bind",
+                name=name,
+                local_path=str(local_path),
+                path=str(host_path),
+            )
+            return str(host_path)
 
         # Named-volume mode: Docker manages the volume lifecycle
         client = await self._get_client()
@@ -544,11 +555,14 @@ class DockerDriver(Driver):
         host_root = await self._resolve_host_root()
 
         if host_root:
-            # Bind-mount mode: name is already a host path, delete directory
-            cargo_path = Path(name)
-            if cargo_path.exists():
-                shutil.rmtree(cargo_path, ignore_errors=True)
-            self._log.info("docker.delete_volume.bind", path=str(cargo_path))
+            local_path = self._local_cargo_path(name)
+            if local_path.exists():
+                shutil.rmtree(local_path, ignore_errors=True)
+            self._log.info(
+                "docker.delete_volume.bind",
+                local_path=str(local_path),
+                path=name,
+            )
         else:
             # Named-volume mode: name is volume name
             try:
@@ -564,8 +578,7 @@ class DockerDriver(Driver):
         host_root = await self._resolve_host_root()
 
         if host_root:
-            # Bind-mount mode: name is already the host path
-            return Path(name).is_dir()
+            return self._local_cargo_path(name).is_dir()
 
         # Named-volume mode
         try:

--- a/pkgs/bay/app/drivers/docker/docker.py
+++ b/pkgs/bay/app/drivers/docker/docker.py
@@ -512,9 +512,28 @@ class DockerDriver(Driver):
 
     # Volume management
 
-    def _local_cargo_path(self, volume_ref: str) -> Path:
-        """Map a host bind path or volume name to Bay's mounted cargo root."""
-        return self._cargo_root_path / Path(volume_ref).name
+    def _local_cargo_path(self, volume_ref: str, host_root: str) -> Path:
+        """Map a validated host bind path or cargo name to Bay's mount."""
+        ref_path = Path(volume_ref)
+        if ref_path.is_absolute():
+            try:
+                relative_ref = ref_path.relative_to(Path(host_root))
+            except ValueError as exc:
+                raise ValueError(
+                    f"Cargo bind path is outside the configured host root: {volume_ref}"
+                ) from exc
+        else:
+            relative_ref = ref_path
+
+        if len(relative_ref.parts) != 1 or not relative_ref.name.startswith(
+            "bay-cargo-"
+        ):
+            raise ValueError(f"Invalid cargo bind reference: {volume_ref}")
+
+        local_path = self._cargo_root_path / relative_ref.name
+        if local_path.is_symlink():
+            raise ValueError(f"Cargo bind path must not be a symbolic link: {volume_ref}")
+        return local_path
 
     async def create_volume(self, name: str, labels: dict[str, str] | None = None) -> str:
         """Create a cargo volume.
@@ -533,7 +552,7 @@ class DockerDriver(Driver):
         if host_root:
             # Create through Bay's mounted path, then return the equivalent
             # Docker-host path for use in the daemon's Binds configuration.
-            local_path = self._local_cargo_path(name)
+            local_path = self._local_cargo_path(name, host_root)
             local_path.mkdir(parents=True, exist_ok=True)
             host_path = Path(host_root) / Path(name).name
             self._log.info(
@@ -555,7 +574,7 @@ class DockerDriver(Driver):
         host_root = await self._resolve_host_root()
 
         if host_root:
-            local_path = self._local_cargo_path(name)
+            local_path = self._local_cargo_path(name, host_root)
             if local_path.exists():
                 shutil.rmtree(local_path, ignore_errors=True)
             self._log.info(
@@ -578,7 +597,7 @@ class DockerDriver(Driver):
         host_root = await self._resolve_host_root()
 
         if host_root:
-            return self._local_cargo_path(name).is_dir()
+            return self._local_cargo_path(name, host_root).is_dir()
 
         # Named-volume mode
         try:

--- a/pkgs/bay/tests/unit/drivers/test_docker_bind_cargo_paths.py
+++ b/pkgs/bay/tests/unit/drivers/test_docker_bind_cargo_paths.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+from app.drivers.docker.docker import DockerDriver
+
+
+class TestDockerBindCargoPaths(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+
+        self.local_root = Path(self.temp_dir.name) / "container-cargos"
+        self.driver = DockerDriver.__new__(DockerDriver)
+        self.driver._cargo_root_path = self.local_root
+        self.driver._log = Mock()
+        self.driver._resolve_host_root = AsyncMock(
+            return_value="/daemon-only/shipyard-cargos"
+        )
+
+    async def test_create_volume_uses_local_mount_and_returns_host_bind_path(
+        self,
+    ) -> None:
+        volume = await self.driver.create_volume("bay-cargo-test")
+
+        self.assertEqual(
+            volume,
+            "/daemon-only/shipyard-cargos/bay-cargo-test",
+        )
+        self.assertTrue((self.local_root / "bay-cargo-test").is_dir())
+
+    async def test_volume_exists_checks_local_mount(self) -> None:
+        (self.local_root / "bay-cargo-test").mkdir(parents=True)
+
+        exists = await self.driver.volume_exists(
+            "/daemon-only/shipyard-cargos/bay-cargo-test"
+        )
+
+        self.assertTrue(exists)
+
+    async def test_delete_volume_removes_directory_from_local_mount(self) -> None:
+        local_path = self.local_root / "bay-cargo-test"
+        local_path.mkdir(parents=True)
+        (local_path / "artifact.txt").write_text("test")
+
+        await self.driver.delete_volume(
+            "/daemon-only/shipyard-cargos/bay-cargo-test"
+        )
+
+        self.assertFalse(local_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pkgs/bay/tests/unit/drivers/test_docker_bind_cargo_paths.py
+++ b/pkgs/bay/tests/unit/drivers/test_docker_bind_cargo_paths.py
@@ -52,6 +52,27 @@ class TestDockerBindCargoPaths(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(local_path.exists())
 
+    async def test_delete_volume_rejects_cargo_root(self) -> None:
+        sentinel = self.local_root / "keep.txt"
+        self.local_root.mkdir(parents=True)
+        sentinel.write_text("keep")
+
+        with self.assertRaises(ValueError):
+            await self.driver.delete_volume("/")
+
+        self.assertTrue(sentinel.is_file())
+
+    async def test_delete_volume_rejects_path_outside_configured_host_root(
+        self,
+    ) -> None:
+        local_path = self.local_root / "bay-cargo-test"
+        local_path.mkdir(parents=True)
+
+        with self.assertRaises(ValueError):
+            await self.driver.delete_volume("/other-root/bay-cargo-test")
+
+        self.assertTrue(local_path.is_dir())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 修改内容

- Docker bind Cargo 通过 Bay 容器内的挂载根目录创建、检查和删除。
- 返回给 Docker daemon 的仍是宿主机绝对目录。
- 仅接受挂载根目录的直接子目录，并校验 `bay-cargo-` 名称前缀。
- 拒绝根目录、目录外路径和符号链接，避免误删或引用错误目录。

## 问题原因

Bay 运行在容器内时，Docker daemon 使用宿主机目录，Bay 进程只能访问映射后的容器目录。旧实现使用宿主机目录执行本地文件操作，因此 bind Cargo 创建和清理会失败。

## 验证

- 专项单元测试：`21 passed`
- 生产组合分支单元测试：`525 passed`
- Ruff：通过
- 实际 Docker bind Cargo 创建、浏览器沙盒运行和级联清理均通过

## Summary by Sourcery

Ensure Docker bind cargo volumes are created, checked, and deleted via Bay's container-mounted cargo root while still returning host-side paths to the Docker daemon.

Bug Fixes:
- Fix bind cargo operations failing when Bay runs inside a container by mapping host bind paths to the container's mounted cargo root before performing filesystem actions.
- Prevent accidental deletion or misuse of directories by rejecting non-cargo paths, paths outside the configured host root, and symbolic links during bind cargo handling.

Tests:
- Add unit tests covering bind cargo creation, existence checks, deletion via the container mount, and validation of invalid or out-of-root paths.