### PR TITLE
fix(docker): allocate session networks from configured pool

### DIFF
--- a/deploy/docker/config.yaml
+++ b/deploy/docker/config.yaml
@@ -29,6 +29,11 @@ driver:
   docker:
     socket: "unix:///var/run/docker.sock"
 
+    # Allocate session bridge networks from a dedicated private pool to avoid
+    # overlap with common 192.168.x.x physical LANs. Each session receives a /24.
+    session_network_pool: "10.252.0.0/16"
+    session_network_prefix: 24
+
     # Bay in container, Ship/Gull in container — use container network direct connect
     connect_mode: container_network
 

--- a/pkgs/bay/app/config.py
+++ b/pkgs/bay/app/config.py
@@ -9,11 +9,12 @@ Configuration sources (in priority order):
 from __future__ import annotations
 
 from functools import lru_cache
+from ipaddress import IPv4Network
 from pathlib import Path
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -37,6 +38,10 @@ class DockerConfig(BaseModel):
 
     socket: str = "unix:///var/run/docker.sock"
 
+    # Address space used for session-scoped bridge networks.
+    session_network_pool: str = "10.252.0.0/16"
+    session_network_prefix: int = Field(default=24, ge=0, le=30)
+
     # 可选：把 runtime 容器接入指定 network（Bay 也需要在该 network 内才能用容器 IP 直连）
     # 为空则不指定 network（使用 Docker 默认网络）
     network: str | None = None
@@ -55,6 +60,25 @@ class DockerConfig(BaseModel):
 
     # 指定固定宿主机端口（None/0 表示随机端口）
     host_port: int | None = None
+
+    @field_validator("session_network_pool")
+    @classmethod
+    def validate_session_network_pool(cls, value: str) -> str:
+        """Require a canonical IPv4 network for deterministic subnet allocation."""
+        try:
+            return str(IPv4Network(value, strict=True))
+        except ValueError as exc:
+            raise ValueError("session_network_pool must be a valid IPv4 network") from exc
+
+    @model_validator(mode="after")
+    def validate_session_network_prefix(self) -> DockerConfig:
+        """Require the allocated subnet prefix to fit inside the configured pool."""
+        pool = IPv4Network(self.session_network_pool)
+        if self.session_network_prefix < pool.prefixlen:
+            raise ValueError(
+                "session_network_prefix must be greater than or equal to the pool prefix"
+            )
+        return self
 
 
 class K8sConfig(BaseModel):

--- a/pkgs/bay/app/drivers/docker/docker.py
+++ b/pkgs/bay/app/drivers/docker/docker.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import shutil
+from ipaddress import IPv4Network, ip_network
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -660,6 +661,24 @@ class DockerDriver(Driver):
         """Generate network name for a session."""
         return f"bay_net_{session_id}"
 
+    @staticmethod
+    def _used_docker_subnets(networks: list[dict[str, Any]]) -> list[IPv4Network]:
+        """Extract valid IPv4 subnets from Docker network inspection results."""
+        used_subnets: list[IPv4Network] = []
+        for network in networks:
+            ipam_configs = network.get("IPAM", {}).get("Config") or []
+            for config in ipam_configs:
+                subnet = config.get("Subnet")
+                if not subnet:
+                    continue
+                try:
+                    parsed = ip_network(subnet, strict=False)
+                except ValueError:
+                    continue
+                if isinstance(parsed, IPv4Network):
+                    used_subnets.append(parsed)
+        return used_subnets
+
     async def create_session_network(self, session_id: str) -> str:
         """Create a session-scoped Docker bridge network.
 
@@ -680,11 +699,31 @@ class DockerDriver(Driver):
 
         settings = get_settings()
         gc_instance_id = settings.gc.get_instance_id()
+        docker_config = settings.driver.docker
+        pool = IPv4Network(docker_config.session_network_pool)
+        used_subnets = self._used_docker_subnets(await client.networks.list())
+        subnet = next(
+            (
+                candidate
+                for candidate in pool.subnets(new_prefix=docker_config.session_network_prefix)
+                if not any(candidate.overlaps(used) for used in used_subnets)
+            ),
+            None,
+        )
+        if subnet is None:
+            raise RuntimeError(
+                "session network pool exhausted: "
+                f"{pool} has no available /{docker_config.session_network_prefix} subnet"
+            )
 
         await client.networks.create(
             {
                 "Name": network_name,
                 "Driver": "bridge",
+                "IPAM": {
+                    "Driver": "default",
+                    "Config": [{"Subnet": str(subnet)}],
+                },
                 "Labels": {
                     "bay.managed": "true",
                     "bay.session_id": session_id,

--- a/pkgs/bay/tests/unit/drivers/test_docker_session_network.py
+++ b/pkgs/bay/tests/unit/drivers/test_docker_session_network.py
@@ -1,0 +1,129 @@
+"""Unit tests for deterministic Docker session-network IPAM."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from app.config import DockerConfig, Settings
+from app.drivers.docker.docker import DockerDriver
+
+
+def _driver_with_client(client: AsyncMock) -> DockerDriver:
+    driver = DockerDriver.__new__(DockerDriver)
+    driver._get_client = AsyncMock(return_value=client)
+    driver._log = MagicMock()
+    return driver
+
+
+def _settings(*, pool: str = "10.252.0.0/16", prefix: int = 24) -> Settings:
+    return Settings(
+        driver={
+            "docker": {
+                "session_network_pool": pool,
+                "session_network_prefix": prefix,
+            }
+        }
+    )
+
+
+class TestDockerSessionNetworkConfig:
+    def test_defaults_use_private_non_lan_pool(self):
+        config = DockerConfig()
+
+        assert config.session_network_pool == "10.252.0.0/16"
+        assert config.session_network_prefix == 24
+
+    def test_pool_and_prefix_are_configurable(self):
+        config = DockerConfig(
+            session_network_pool="10.200.0.0/20",
+            session_network_prefix=26,
+        )
+
+        assert config.session_network_pool == "10.200.0.0/20"
+        assert config.session_network_prefix == 26
+
+    @pytest.mark.parametrize(
+        ("pool", "prefix"),
+        [
+            ("not-a-network", 24),
+            ("2001:db8::/64", 24),
+            ("10.252.0.0/16", 15),
+            ("10.252.0.0/16", 33),
+        ],
+    )
+    def test_invalid_pool_or_prefix_is_rejected(self, pool: str, prefix: int):
+        with pytest.raises(ValidationError):
+            DockerConfig(
+                session_network_pool=pool,
+                session_network_prefix=prefix,
+            )
+
+
+class TestDockerSessionNetworkIPAM:
+    @pytest.mark.asyncio
+    async def test_create_emits_ipam_for_first_deterministic_subnet(self):
+        client = AsyncMock()
+        client.networks.list.return_value = []
+        driver = _driver_with_client(client)
+
+        with patch(
+            "app.drivers.docker.docker.get_settings",
+            return_value=_settings(pool="10.200.0.0/16", prefix=24),
+        ):
+            result = await driver.create_session_network("session-1")
+
+        assert result == "bay_net_session-1"
+        payload = client.networks.create.await_args.args[0]
+        assert payload["IPAM"] == {
+            "Driver": "default",
+            "Config": [{"Subnet": "10.200.0.0/24"}],
+        }
+
+    @pytest.mark.asyncio
+    async def test_create_skips_subnets_used_by_existing_networks(self):
+        client = AsyncMock()
+        client.networks.list.return_value = [
+            {
+                "Name": "existing-1",
+                "IPAM": {"Config": [{"Subnet": "10.252.0.0/24"}]},
+            },
+            {
+                "Name": "existing-2",
+                "IPAM": {"Config": [{"Subnet": "10.252.1.0/24"}]},
+            },
+        ]
+        driver = _driver_with_client(client)
+
+        with patch(
+            "app.drivers.docker.docker.get_settings",
+            return_value=_settings(),
+        ):
+            await driver.create_session_network("session-2")
+
+        payload = client.networks.create.await_args.args[0]
+        assert payload["IPAM"]["Config"] == [{"Subnet": "10.252.2.0/24"}]
+
+    @pytest.mark.asyncio
+    async def test_exhausted_pool_raises_without_automatic_ipam_fallback(self):
+        client = AsyncMock()
+        client.networks.list.return_value = [
+            {
+                "Name": "existing",
+                "IPAM": {"Config": [{"Subnet": "10.252.0.0/30"}]},
+            }
+        ]
+        driver = _driver_with_client(client)
+
+        with (
+            patch(
+                "app.drivers.docker.docker.get_settings",
+                return_value=_settings(pool="10.252.0.0/30", prefix=30),
+            ),
+            pytest.raises(RuntimeError, match="session network pool exhausted"),
+        ):
+            await driver.create_session_network("session-3")
+
+        client.networks.create.assert_not_awaited()


### PR DESCRIPTION
## Summary

- add validated Docker session-network pool and prefix settings
- allocate Bay session bridge networks with explicit Docker IPAM instead of Docker's automatic address pool
- skip any candidate subnet overlapping an existing Docker network
- fail explicitly when the configured pool is exhausted instead of silently falling back to automatic IPAM
- document the production Docker default: `10.252.0.0/16` split into `/24` session networks

## Motivation

On Docker Desktop, automatic bridge allocation can select `192.168.0.0/20`, which overlaps common physical `192.168.x.x` LANs and breaks container access to LAN dependencies. Explicit per-session IPAM keeps sandbox isolation while avoiding Docker Desktop's opaque default pool selection.

## Validation

- `cd pkgs/bay && uv sync --frozen`
- `cd pkgs/bay && uv run pytest tests/unit/drivers/test_docker_session_network.py -v --tb=short` — **9 passed**
- `cd pkgs/bay && uv run ruff check app/config.py app/drivers/docker/docker.py tests/unit/drivers/test_docker_session_network.py` — **passed**
- `cd pkgs/bay && uv run pytest tests/unit -v --tb=short` — **365 passed, 121 errors**. The errors are outside this change and occur during async SQLAlchemy test setup because `greenlet` is not installed by the current locked dependency environment. The focused IPAM tests pass using the same environment.

## Scope

This change only affects newly created Docker session networks. It does not alter existing networks, Cargo paths, deployment secrets, or persistent data.

## Summary by Sourcery

Configure deterministic Docker session bridge networks from a validated private address pool and avoid overlapping existing Docker networks.

New Features:
- Introduce configurable Docker session network pool and subnet prefix for session-scoped bridge networks.

Enhancements:
- Add validation for Docker session network pool and prefix to ensure canonical IPv4 networks and compatible prefixes.
- Derive session network subnets from the configured pool and explicitly pass IPAM configuration when creating Docker networks.
- Document the production Docker session network pool and prefix in the Docker deploy config.

Tests:
- Add unit tests covering Docker session network configuration validation and deterministic IPAM behavior, including pool exhaustion handling.