### PR TITLE
fix(bay): support workspace path aliases and UTF-8 download filenames

### DIFF
--- a/pkgs/bay/app/api/v1/capabilities.py
+++ b/pkgs/bay/app/api/v1/capabilities.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import time
 from pathlib import Path
 from typing import Annotated, Any
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, File, Form, Query, UploadFile
 from fastapi.responses import Response
@@ -32,6 +33,12 @@ from app.validators.path import (
 )
 
 router = APIRouter()
+
+
+def _attachment_content_disposition(filename: str) -> str:
+    """Build an ASCII-only attachment header that supports Unicode filenames."""
+    encoded_filename = quote(filename, safe="")
+    return f"attachment; filename*=UTF-8''{encoded_filename}"
 
 
 # -- Path validation dependencies --
@@ -829,5 +836,5 @@ async def download_file(
     return Response(
         content=content,
         media_type="application/octet-stream",
-        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        headers={"Content-Disposition": _attachment_content_disposition(filename)},
     )

--- a/pkgs/bay/app/validators/path.py
+++ b/pkgs/bay/app/validators/path.py
@@ -19,7 +19,7 @@ def validate_relative_path(path: str, *, field_name: str = "path") -> str:
 
     Rules:
     1. Must not be empty
-    2. Must not be absolute (start with /)
+    2. May use /workspace as an explicit workspace-root alias
     3. Must not contain null bytes
     4. After normalization, must not escape workspace (start with ..)
 
@@ -55,6 +55,17 @@ def validate_relative_path(path: str, *, field_name: str = "path") -> str:
             message=f"{field_name} contains invalid characters",
             details={"field": field_name, "reason": "null_byte"},
         )
+
+    # AstrBot and some other clients expose sandbox paths as /workspace/..., while
+    # the Bay/Ship API uses paths relative to that directory.  AstrBot versions
+    # that strip only the leading slash send the compatibility form
+    # workspace/....  Normalize both forms before applying the traversal checks.
+    if path == "/workspace" or path == "workspace":
+        path = "."
+    elif path.startswith("/workspace/"):
+        path = path.removeprefix("/workspace/")
+    elif path.startswith("workspace/"):
+        path = path.removeprefix("workspace/")
 
     p = PurePosixPath(path)
 

--- a/pkgs/bay/tests/integration/filesystem/test_transfer.py
+++ b/pkgs/bay/tests/integration/filesystem/test_transfer.py
@@ -43,6 +43,34 @@ async def test_upload_and_download_text():
             assert d.content == content
 
 
+async def test_upload_and_download_unicode_filename_with_workspace_alias():
+    """Unicode filenames and AstrBot's stripped /workspace form are supported."""
+    async with httpx.AsyncClient(base_url=BAY_BASE_URL, headers=AUTH_HEADERS) as client:
+        async with create_sandbox(client) as sandbox:
+            sid = sandbox["id"]
+            content = "中文文件内容".encode()
+            path = "中文测试文件.txt"
+
+            u = await client.post(
+                f"/v1/sandboxes/{sid}/filesystem/upload",
+                files={"file": (path, content, "text/plain")},
+                data={"path": path},
+                timeout=120.0,
+            )
+            assert u.status_code == 200
+
+            d = await client.get(
+                f"/v1/sandboxes/{sid}/filesystem/download",
+                params={"path": f"workspace/{path}"},
+                timeout=30.0,
+            )
+            assert d.status_code == 200
+            assert d.content == content
+            assert d.headers["content-disposition"].startswith(
+                "attachment; filename*=UTF-8''"
+            )
+
+
 async def test_upload_and_download_binary():
     """Upload binary file and download it back."""
     async with httpx.AsyncClient(base_url=BAY_BASE_URL, headers=AUTH_HEADERS) as client:

--- a/pkgs/bay/tests/unit/api/test_capabilities_file_download.py
+++ b/pkgs/bay/tests/unit/api/test_capabilities_file_download.py
@@ -1,0 +1,27 @@
+"""Unit tests for filesystem download response headers."""
+
+from __future__ import annotations
+
+from fastapi.responses import Response
+
+from app.api.v1.capabilities import _attachment_content_disposition
+
+
+def test_content_disposition_encodes_unicode_filename() -> None:
+    header = _attachment_content_disposition("中文测试文件.txt")
+
+    assert header == (
+        "attachment; filename*=UTF-8''"
+        "%E4%B8%AD%E6%96%87%E6%B5%8B%E8%AF%95%E6%96%87%E4%BB%B6.txt"
+    )
+    assert header.isascii()
+    assert Response(headers={"Content-Disposition": header}).headers[
+        "content-disposition"
+    ] == header
+
+
+def test_content_disposition_escapes_header_metacharacters() -> None:
+    header = _attachment_content_disposition('report "final".txt')
+
+    assert header == "attachment; filename*=UTF-8''report%20%22final%22.txt"
+    assert header.isascii()

--- a/pkgs/bay/tests/unit/path/test_path_validator.py
+++ b/pkgs/bay/tests/unit/path/test_path_validator.py
@@ -59,6 +59,20 @@ class TestValidateRelativePath:
     def test_current_dir_only(self) -> None:
         assert validate_relative_path(".") == "."
 
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            ("/workspace/file.txt", "file.txt"),
+            ("/workspace/a/b.txt", "a/b.txt"),
+            ("/workspace", "."),
+            ("workspace/file.txt", "file.txt"),
+            ("workspace/a/b.txt", "a/b.txt"),
+            ("workspace", "."),
+        ],
+    )
+    def test_normalizes_workspace_root_alias(self, path: str, expected: str) -> None:
+        assert validate_relative_path(path) == expected
+
     # --- Normalization edge cases ---
 
     def test_normalizes_double_slash(self) -> None:
@@ -91,10 +105,15 @@ class TestValidateRelativePath:
         assert exc.value.code == "invalid_path"
         assert exc.value.details["reason"] == "absolute_path"
 
-    def test_rejects_absolute_path_container_mount(self) -> None:
+    def test_rejects_traversal_through_workspace_alias(self) -> None:
         with pytest.raises(InvalidPathError) as exc:
-            validate_relative_path("/workspace/file.txt")
-        assert exc.value.details["reason"] == "absolute_path"
+            validate_relative_path("/workspace/../etc/passwd")
+        assert exc.value.details["reason"] == "path_traversal"
+
+    def test_rejects_traversal_through_stripped_workspace_alias(self) -> None:
+        with pytest.raises(InvalidPathError) as exc:
+            validate_relative_path("workspace/../../etc/passwd")
+        assert exc.value.details["reason"] == "path_traversal"
 
     def test_rejects_traversal_at_start(self) -> None:
         with pytest.raises(InvalidPathError) as exc:


### PR DESCRIPTION
## Summary

Fix file download failures for sandbox clients that use `/workspace`-style paths or Unicode filenames.

## Changes

- Accept `/workspace/...` and `workspace/...` as aliases for the sandbox workspace root.
- Preserve path traversal protection after alias normalization.
- Encode `Content-Disposition` filenames using RFC 5987 UTF-8 format.
- Support downloading files with Chinese and other non-ASCII filenames.
- Add unit and integration tests for workspace aliases, traversal protection, Unicode filenames, and header escaping.

## Motivation

Some clients expose sandbox files using paths such as `/workspace/file.txt` or `workspace/file.txt`, while the Bay API expects paths relative to the workspace root. This causes valid files to be reported as missing.

The previous `Content-Disposition` header also embedded filenames directly and could not reliably handle non-ASCII filenames.

## Security

Workspace aliases are normalized before traversal validation. Paths such as `/workspace/../etc/passwd` and `workspace/../../etc/passwd` remain rejected.

Filename values are percent-encoded before being placed in the response header.

## Validation

- Added unit tests for path normalization and traversal protection.
- Added unit tests for UTF-8 `Content-Disposition` headers.
- Added integration coverage for uploading and downloading a file with a Chinese filename.

Closes #21

## Summary by Sourcery

Support workspace path aliases and Unicode-safe filenames when downloading sandbox files.

New Features:
- Allow filesystem operations to accept /workspace and workspace path aliases for the sandbox workspace root.
- Generate RFC 5987 UTF-8 encoded Content-Disposition headers for file downloads to support non-ASCII filenames.

Bug Fixes:
- Prevent valid sandbox files addressed via /workspace-style paths from being incorrectly rejected as missing.
- Ensure path traversal remains blocked after normalizing workspace aliases, including crafted /workspace/../ sequences.

Enhancements:
- Refine relative path validation to normalize workspace aliases before applying absolute path and traversal checks.

Tests:
- Add unit tests for workspace alias normalization and traversal rejection cases in the path validator.
- Add unit tests verifying UTF-8, ASCII-only Content-Disposition headers and escaping of header metacharacters for file downloads.
- Add integration coverage for uploading and downloading files with Unicode filenames via workspace path aliases.